### PR TITLE
Add sample_test macro and some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+**/target
 /Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = ["sample-std"]
+members = ["sample-std", "sample-test-macros"]
 
 [dependencies]
 lazy_static = "1.4"
 quickcheck="1.0"
 sample-std = { path = "sample-std" }
+sample-test-macros = { path = "sample-test-macros" }

--- a/sample-std/tests/recurse.rs
+++ b/sample-std/tests/recurse.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::ops::Range;
+
+use sample_std::{
+    choice,
+    recursive::{Recursion, RecursiveSampler},
+    Random, Regex, Sample, VecSampler,
+};
+use sample_test::{lazy_static, sample_test};
+
+#[derive(Clone, Debug)]
+pub enum Json {
+    Null,
+    Bool(bool),
+    Number(f64),
+    String(String),
+    Array(Vec<Json>),
+    Map(HashMap<String, Json>),
+}
+
+impl Json {
+    fn depth(&self) -> usize {
+        match self {
+            Json::Array(bs) => bs.iter().map(Json::depth).max().unwrap_or(1),
+            _ => 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct JsonSampler {
+    branch: Range<usize>,
+}
+
+impl JsonSampler {
+    fn string() -> impl Sample<Output = String> {
+        Regex::new("[a-z]{20}")
+    }
+
+    fn array(&self, inner: JsonTree) -> impl Sample<Output = Vec<Json>> {
+        VecSampler {
+            length: self.branch.clone(),
+            el: inner,
+        }
+    }
+}
+
+impl Sample for JsonSampler {
+    type Output = Json;
+
+    fn generate(&self, g: &mut Random) -> Json {
+        match g.gen_range(0..=3) {
+            0 => Json::Bool(g.arbitrary()),
+            1 => Json::Number(g.arbitrary()),
+            2 => Json::String(Self::string().generate(g)),
+            _ => Json::Null,
+        }
+    }
+}
+
+pub type JsonTree = RecursiveSampler<JsonSampler>;
+
+impl Recursion for JsonSampler {
+    type Output = Json;
+
+    fn recurse(&self, g: &mut Random, inner: JsonTree) -> Self::Output {
+        match g.gen_range(0..=1) {
+            _ => Json::Array(self.array(inner).generate(g)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Tree {
+    Branch(Vec<Tree>),
+    Leaf(usize),
+}
+
+impl Tree {
+    fn depth(&self) -> usize {
+        match self {
+            Tree::Branch(bs) => 1 + bs.iter().map(Tree::depth).max().unwrap_or(0),
+            Tree::Leaf(..) => 0,
+        }
+    }
+
+    fn level(self) -> Box<dyn Iterator<Item = Vec<Tree>>> {
+        match self {
+            Tree::Branch(l) => Box::new(std::iter::once(l)),
+            Tree::Leaf(_) => Box::new(std::iter::empty()),
+        }
+    }
+
+    fn leaf(self) -> impl Iterator<Item = usize> {
+        match self {
+            Self::Leaf(v) => Some(v).into_iter(),
+            _ => None.into_iter(),
+        }
+    }
+}
+
+pub type TreeSampler = Box<dyn Sample<Output = Tree> + Send + Sync>;
+
+pub fn sample_tree<LS>(depth: Range<usize>, branch: Range<usize>, leaf: LS) -> TreeSampler
+where
+    LS: Sample<Output = usize> + Clone + Send + Sync + 'static,
+{
+    let leaf = Box::new(leaf.wrap(Tree::leaf, Tree::Leaf));
+    let mut inner: TreeSampler = leaf.clone();
+    for ix in (0..(depth.end - 1)).rev() {
+        let el = if ix > depth.start {
+            Box::new(choice([leaf.clone(), inner]))
+        } else {
+            inner
+        };
+
+        let length = if ix < depth.start - 1 {
+            1..depth.end
+        } else {
+            branch.clone()
+        };
+
+        let level = VecSampler { length, el };
+
+        inner = Box::new(level.wrap(Tree::level, Tree::Branch))
+    }
+
+    inner
+}
+
+lazy_static! {
+    static ref TREE: TreeSampler = sample_tree(2..5, 0..3, 0..100);
+}
+
+#[sample_test]
+fn tree_bounds(#[sample(TREE)] tree: Tree) {
+    assert!(tree.depth() >= 2);
+    assert!(tree.depth() < 5);
+}
+
+lazy_static! {
+    static ref JSON: JsonTree = JsonTree {
+        depth: Some(0..3),
+        node: JsonSampler { branch: 1..10 }
+    };
+}
+
+#[sample_test]
+fn json(#[sample(JSON)] json: Json) {
+    assert!(json.depth() < 4);
+}

--- a/sample-test-macros/Cargo.toml
+++ b/sample-test-macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sample-test-macros"
+version = "0.1.0"
+license = "Apache-2.0"
+description = "proc-macros used by sample-test"
+edition = "2021"
+
+[lib]
+name = "sample_test_macros"
+path = "src/lib.rs"
+proc-macro = true
+
+[dependencies]
+lazy_static = "1.4"
+proc-macro2 = "1.0"
+quote = "1.0"
+sample-std = { path = "../sample-std" }
+syn = { version = "1.0", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+quickcheck = "1.0"
+sample-test = { path = ".." }

--- a/sample-test-macros/src/lib.rs
+++ b/sample-test-macros/src/lib.rs
@@ -1,0 +1,143 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+extern crate quote;
+extern crate syn;
+
+use std::mem;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    parse::{Parse, Parser},
+    parse_quote,
+    spanned::Spanned,
+};
+
+#[proc_macro_attribute]
+pub fn sample_test(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let output = match syn::Item::parse.parse(input.clone()) {
+        Ok(syn::Item::Fn(mut item_fn)) => {
+            let mut inputs = syn::punctuated::Punctuated::new();
+            let mut generators = Vec::new();
+            let mut unwraps = Vec::new();
+            let mut errors = Vec::new();
+
+            item_fn
+                .sig
+                .inputs
+                .iter_mut()
+                .for_each(|input| match *input {
+                    syn::FnArg::Typed(syn::PatType {
+                        ref pat,
+                        ref mut ty,
+                        ref mut attrs,
+                        ..
+                    }) => {
+                        let ix = attrs
+                            .iter()
+                            .position(|a| a.path.segments.iter().map(|s| &s.ident).eq(["sample"]));
+                        if let Some(ix) = ix {
+                            let id = format_ident!("_Sampletest{}", generators.len());
+                            generators.push((id.clone(), ty.clone(), attrs.remove(ix)));
+                            inputs.push(parse_quote!(_: #id));
+                            *ty = parse_quote!(#id);
+                            let unwrap_stmt: syn::Stmt = parse_quote!(let #pat = #pat.0;);
+                            unwraps.push(unwrap_stmt);
+                        } else {
+                            inputs.push(parse_quote!(_: #ty));
+                        }
+                    }
+                    _ => errors.push(syn::parse::Error::new(
+                        input.span(),
+                        "unsupported kind of function argument",
+                    )),
+                });
+
+            if errors.is_empty() {
+                let gen_impls = generators.iter().map(|(ty_id, ty, attr)| {
+                    let literal = &attr.tokens;
+
+                    quote! {
+                        #[derive(Clone, Debug)]
+                        struct #ty_id(#ty);
+
+                        impl ::quickcheck::Arbitrary for #ty_id {
+                            fn arbitrary(g: &mut ::quickcheck::Gen) -> Self {
+                                let mut random = ::sample_std::Random::new(g.size());
+                                #ty_id(::sample_std::Sample::generate(
+                                    ::std::ops::Deref::deref(&(#literal)),
+                                    &mut random,
+                                ))
+                            }
+
+                            fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+                                Box::new(::sample_std::Sample::shrink(
+                                    ::std::ops::Deref::deref(&(#literal)),
+                                    self.0.clone()
+                                ).map(|v| #ty_id(v)))
+                            }
+                        }
+                    }
+                });
+
+                let attrs = mem::replace(&mut item_fn.attrs, Vec::new());
+                let name = &item_fn.sig.ident;
+                let fn_type = syn::TypeBareFn {
+                    lifetimes: None,
+                    unsafety: item_fn.sig.unsafety.clone(),
+                    abi: item_fn.sig.abi.clone(),
+                    fn_token: <syn::Token![fn]>::default(),
+                    paren_token: syn::token::Paren::default(),
+                    inputs,
+                    variadic: item_fn.sig.variadic.clone(),
+                    output: item_fn.sig.output.clone(),
+                };
+
+                item_fn.block.stmts = unwraps
+                    .into_iter()
+                    .chain(item_fn.block.stmts.iter().cloned())
+                    .collect();
+
+                quote! {
+                    #[test]
+                    #(#attrs)*
+                    fn #name() {
+                        #(#gen_impls)*
+
+                        #item_fn
+                        ::quickcheck::quickcheck(#name as #fn_type)
+                    }
+                }
+            } else {
+                errors
+                    .iter()
+                    .map(syn::parse::Error::to_compile_error)
+                    .collect()
+            }
+        }
+        Ok(syn::Item::Static(mut item_static)) => {
+            let attrs = mem::replace(&mut item_static.attrs, Vec::new());
+            let name = &item_static.ident;
+
+            quote! {
+                #[test]
+                #(#attrs)*
+                fn #name() {
+                    #item_static
+                    ::quickcheck::quickcheck(#name)
+                }
+            }
+        }
+        _ => {
+            let span = proc_macro2::TokenStream::from(input).span();
+            let msg = "#[quickcheck] is only supported on statics and functions";
+
+            syn::parse::Error::new(span, msg).to_compile_error()
+        }
+    };
+
+    output.into()
+}
+
+#[cfg(test)]
+mod tests {}

--- a/sample-test-macros/tests/macro.rs
+++ b/sample-test-macros/tests/macro.rs
@@ -1,0 +1,16 @@
+use sample_test::TestResult;
+use sample_test::{lazy_static, sample_test};
+use std::ops::Range;
+
+lazy_static! {
+    static ref RANGE: Range<usize> = 10..20;
+}
+
+#[sample_test]
+fn min(#[sample(RANGE)] x: usize, #[sample(RANGE)] y: usize) -> TestResult {
+    if x < y {
+        TestResult::discard()
+    } else {
+        TestResult::from_bool(::std::cmp::min(x, y) == y)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+pub use lazy_static::lazy_static;
+pub use sample_test_macros::sample_test;
+
 pub use quickcheck::{Arbitrary, Gen, TestResult, Testable};

--- a/tests/recurse.rs
+++ b/tests/recurse.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::ops::Range;
+
+use sample_std::{
+    choice,
+    recursive::{Recursion, RecursiveSampler},
+    Random, Regex, Sample, VecSampler,
+};
+use sample_test::{lazy_static, sample_test};
+
+#[derive(Clone, Debug)]
+pub enum Json {
+    Null,
+    Bool(bool),
+    Number(f64),
+    String(String),
+    Array(Vec<Json>),
+    Map(HashMap<String, Json>),
+}
+
+impl Json {
+    fn depth(&self) -> usize {
+        match self {
+            Json::Array(bs) => bs.iter().map(Json::depth).max().unwrap_or(1),
+            _ => 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct JsonSampler {
+    branch: Range<usize>,
+}
+
+impl JsonSampler {
+    fn string() -> impl Sample<Output = String> {
+        Regex::new("[a-z]{20}")
+    }
+
+    fn array(&self, inner: JsonTree) -> impl Sample<Output = Vec<Json>> {
+        VecSampler {
+            length: self.branch.clone(),
+            el: inner,
+        }
+    }
+}
+
+impl Sample for JsonSampler {
+    type Output = Json;
+
+    fn generate(&self, g: &mut Random) -> Json {
+        match g.gen_range(0..=3) {
+            0 => Json::Bool(g.arbitrary()),
+            1 => Json::Number(g.arbitrary()),
+            2 => Json::String(Self::string().generate(g)),
+            _ => Json::Null,
+        }
+    }
+}
+
+pub type JsonTree = RecursiveSampler<JsonSampler>;
+
+impl Recursion for JsonSampler {
+    type Output = Json;
+
+    fn recurse(&self, g: &mut Random, inner: JsonTree) -> Self::Output {
+        match g.gen_range(0..=1) {
+            _ => Json::Array(self.array(inner).generate(g)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Tree {
+    Branch(Vec<Tree>),
+    Leaf(usize),
+}
+
+impl Tree {
+    fn depth(&self) -> usize {
+        match self {
+            Tree::Branch(bs) => 1 + bs.iter().map(Tree::depth).max().unwrap_or(0),
+            Tree::Leaf(..) => 0,
+        }
+    }
+
+    fn level(self) -> Box<dyn Iterator<Item = Vec<Tree>>> {
+        match self {
+            Tree::Branch(l) => Box::new(std::iter::once(l)),
+            Tree::Leaf(_) => Box::new(std::iter::empty()),
+        }
+    }
+
+    fn leaf(self) -> impl Iterator<Item = usize> {
+        match self {
+            Self::Leaf(v) => Some(v).into_iter(),
+            _ => None.into_iter(),
+        }
+    }
+}
+
+pub type TreeSampler = Box<dyn Sample<Output = Tree> + Send + Sync>;
+
+pub fn sample_tree<LS>(depth: Range<usize>, branch: Range<usize>, leaf: LS) -> TreeSampler
+where
+    LS: Sample<Output = usize> + Clone + Send + Sync + 'static,
+{
+    let leaf = Box::new(leaf.wrap(Tree::leaf, Tree::Leaf));
+    let mut inner: TreeSampler = leaf.clone();
+    for ix in (0..(depth.end - 1)).rev() {
+        let el = if ix > depth.start {
+            Box::new(choice([leaf.clone(), inner]))
+        } else {
+            inner
+        };
+
+        let length = if ix < depth.start - 1 {
+            1..depth.end
+        } else {
+            branch.clone()
+        };
+
+        let level = VecSampler { length, el };
+
+        inner = Box::new(level.wrap(Tree::level, Tree::Branch))
+    }
+
+    inner
+}
+
+lazy_static! {
+    static ref TREE: TreeSampler = sample_tree(2..5, 0..3, 0..100);
+}
+
+#[sample_test]
+fn tree_bounds(#[sample(TREE)] tree: Tree) {
+    assert!(tree.depth() >= 2);
+    assert!(tree.depth() < 5);
+}
+
+lazy_static! {
+    static ref JSON: JsonTree = JsonTree {
+        depth: Some(0..3),
+        node: JsonSampler { branch: 1..10 }
+    };
+}
+
+#[sample_test]
+fn json(#[sample(JSON)] json: Json) {
+    assert!(json.depth() < 4);
+}


### PR DESCRIPTION
This is pretty ugly currently. It is a thin wrapper around `quickcheck!` that creates newtypes for all the different samplers to make them `Arbitrary`.

This basically forces the use of `lazy_static` for samplers. I'd love to clean that all up and fix this requirement, but that would require a larger rework of more `quickcheck` stuff. I'm still investigating that, but this works as an MVP for now.