### PR TITLE
Samplers for the arrow2 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = ["sample-std", "sample-test-macros"]
+members = ["sample-std", "sample-test-macros", "sample-arrow2"]
 
 [dependencies]
 lazy_static = "1.4"

--- a/sample-arrow2/Cargo.toml
+++ b/sample-arrow2/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sample-arrow2"
+version = "0.1.0"
+license = "Apache-2.0"
+description = "Samplers for arrow2 for use with sample-test"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sample-std = { path = "../sample-std" }
+arrow2 = "0.17"
+
+[dev-dependencies]
+quickcheck="1.0"
+sample-test = { path = ".." }
+lazy_static = "1.4"

--- a/sample-arrow2/src/array.rs
+++ b/sample-arrow2/src/array.rs
@@ -69,7 +69,7 @@ where
                     .iter()
                     .map(|f| {
                         ArbitraryArray {
-                            len: (len.end - 1)..len.end,
+                            len: (len.end.saturating_sub(1))..len.end,
                             is_nullable: f.is_nullable,
                             ..self.clone()
                         }

--- a/sample-arrow2/src/array.rs
+++ b/sample-arrow2/src/array.rs
@@ -1,0 +1,111 @@
+use std::ops::Range;
+
+use arrow2::{array::Array, datatypes::DataType};
+use sample_std::{valid_f32, valid_f64, Random, Sample};
+
+use crate::{
+    datatypes::sample_data_type,
+    list::ListSampler,
+    primitive::{arbitrary_boxed_primitive, boxed_primitive},
+    struct_::StructSampler,
+};
+
+pub type ArraySampler = Box<dyn Sample<Output = Box<dyn Array>> + Send + Sync>;
+
+#[derive(Clone, Debug)]
+pub struct ArbitrarySampler<N, AN, V> {
+    pub data_type_depth: usize,
+    pub names: N,
+    pub nullable: AN,
+
+    pub branch: Range<usize>,
+    pub len: Range<usize>,
+    pub null: V,
+    pub is_nullable: bool,
+}
+
+impl<N, AN, V> Sample for ArbitrarySampler<N, AN, V>
+where
+    N: Sample<Output = String> + Send + Sync + Clone + 'static,
+    AN: Sample<Output = bool> + Send + Sync + Clone + 'static,
+    V: Sample<Output = bool> + Send + Sync + Clone + 'static,
+{
+    type Output = Box<dyn Array>;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        let dt = sample_data_type(
+            self.data_type_depth,
+            self.names.clone(),
+            self.nullable.clone(),
+        )
+        .generate(g);
+
+        sampler_from_data_type(
+            &dt,
+            self.branch.clone(),
+            self.len.clone(),
+            self.null.clone(),
+            self.is_nullable,
+        )
+        .generate(g)
+    }
+}
+
+pub fn sampler_from_data_type<V>(
+    data_type: &DataType,
+    branch: Range<usize>,
+    len: Range<usize>,
+    null: V,
+    is_nullable: bool,
+) -> ArraySampler
+where
+    V: Sample<Output = bool> + Send + Sync + Clone + 'static,
+{
+    let current_null = if is_nullable {
+        Some(null.clone())
+    } else {
+        None
+    };
+
+    match data_type {
+        DataType::Float32 => boxed_primitive(valid_f32(), len, current_null),
+        DataType::Float64 => boxed_primitive(valid_f64(), len, current_null),
+        DataType::Int8 => arbitrary_boxed_primitive::<i8, _>(len, current_null),
+        DataType::Int16 => arbitrary_boxed_primitive::<i16, _>(len, current_null),
+        DataType::Int32 => arbitrary_boxed_primitive::<i32, _>(len, current_null),
+        DataType::Int64 => arbitrary_boxed_primitive::<i64, _>(len, current_null),
+        DataType::UInt8 => arbitrary_boxed_primitive::<u8, _>(len, current_null),
+        DataType::UInt16 => arbitrary_boxed_primitive::<u16, _>(len, current_null),
+        DataType::UInt32 => arbitrary_boxed_primitive::<u32, _>(len, current_null),
+        DataType::UInt64 => arbitrary_boxed_primitive::<u64, _>(len, current_null),
+        DataType::Struct(fields) => Box::new(StructSampler {
+            data_type: data_type.clone(),
+            null: current_null,
+            values: fields
+                .iter()
+                .map(|f| {
+                    sampler_from_data_type(
+                        f.data_type(),
+                        branch.clone(),
+                        (len.end - 1)..len.end,
+                        null.clone(),
+                        f.is_nullable,
+                    )
+                })
+                .collect(),
+        }),
+        DataType::List(field) => Box::new(ListSampler {
+            data_type: data_type.clone(),
+            len: len.clone(),
+            null: current_null,
+            inner: sampler_from_data_type(
+                field.data_type(),
+                branch.clone(),
+                (branch.start * len.start)..(branch.end * len.end),
+                null.clone(),
+                field.is_nullable,
+            ),
+        }),
+        dt => panic!("not implemented: {:?}", dt),
+    }
+}

--- a/sample-arrow2/src/array.rs
+++ b/sample-arrow2/src/array.rs
@@ -1,10 +1,10 @@
 use std::ops::Range;
 
 use arrow2::{array::Array, datatypes::DataType};
-use sample_std::{valid_f32, valid_f64, Random, Sample};
+use sample_std::{valid_f32, valid_f64, Chained, Sample};
 
 use crate::{
-    datatypes::sample_data_type,
+    datatypes::DataTypeSampler,
     list::ListSampler,
     primitive::{arbitrary_boxed_primitive, boxed_primitive},
     struct_::StructSampler,
@@ -12,100 +12,83 @@ use crate::{
 
 pub type ArraySampler = Box<dyn Sample<Output = Box<dyn Array>> + Send + Sync>;
 
-#[derive(Clone, Debug)]
-pub struct ArbitrarySampler<N, AN, V> {
-    pub data_type_depth: usize,
-    pub names: N,
-    pub nullable: AN,
+pub type ChainedArraySampler =
+    Box<dyn Sample<Output = Chained<DataType, Box<dyn Array>>> + Send + Sync>;
 
+#[derive(Clone, Debug)]
+pub struct ArbitraryArray<N, V> {
+    pub names: N,
     pub branch: Range<usize>,
     pub len: Range<usize>,
     pub null: V,
     pub is_nullable: bool,
 }
 
-impl<N, AN, V> Sample for ArbitrarySampler<N, AN, V>
+impl<N, V> ArbitraryArray<N, V>
 where
     N: Sample<Output = String> + Send + Sync + Clone + 'static,
-    AN: Sample<Output = bool> + Send + Sync + Clone + 'static,
     V: Sample<Output = bool> + Send + Sync + Clone + 'static,
 {
-    type Output = Box<dyn Array>;
-
-    fn generate(&self, g: &mut Random) -> Self::Output {
-        let dt = sample_data_type(
-            self.data_type_depth,
-            self.names.clone(),
-            self.nullable.clone(),
-        )
-        .generate(g);
-
-        sampler_from_data_type(
-            &dt,
-            self.branch.clone(),
-            self.len.clone(),
-            self.null.clone(),
-            self.is_nullable,
-        )
-        .generate(g)
+    pub fn with_len(&self, len: usize) -> Self {
+        Self {
+            len: len..(len + 1),
+            ..self.clone()
+        }
     }
-}
 
-pub fn sampler_from_data_type<V>(
-    data_type: &DataType,
-    branch: Range<usize>,
-    len: Range<usize>,
-    null: V,
-    is_nullable: bool,
-) -> ArraySampler
-where
-    V: Sample<Output = bool> + Send + Sync + Clone + 'static,
-{
-    let current_null = if is_nullable {
-        Some(null.clone())
-    } else {
-        None
-    };
+    pub fn arbitrary_array(self, data_type_sampler: DataTypeSampler) -> ChainedArraySampler {
+        Box::new(data_type_sampler.chain_resample(
+            move |data_type| self.sampler_from_data_type(&data_type),
+            100,
+        ))
+    }
 
-    match data_type {
-        DataType::Float32 => boxed_primitive(valid_f32(), len, current_null),
-        DataType::Float64 => boxed_primitive(valid_f64(), len, current_null),
-        DataType::Int8 => arbitrary_boxed_primitive::<i8, _>(len, current_null),
-        DataType::Int16 => arbitrary_boxed_primitive::<i16, _>(len, current_null),
-        DataType::Int32 => arbitrary_boxed_primitive::<i32, _>(len, current_null),
-        DataType::Int64 => arbitrary_boxed_primitive::<i64, _>(len, current_null),
-        DataType::UInt8 => arbitrary_boxed_primitive::<u8, _>(len, current_null),
-        DataType::UInt16 => arbitrary_boxed_primitive::<u16, _>(len, current_null),
-        DataType::UInt32 => arbitrary_boxed_primitive::<u32, _>(len, current_null),
-        DataType::UInt64 => arbitrary_boxed_primitive::<u64, _>(len, current_null),
-        DataType::Struct(fields) => Box::new(StructSampler {
-            data_type: data_type.clone(),
-            null: current_null,
-            values: fields
-                .iter()
-                .map(|f| {
-                    sampler_from_data_type(
-                        f.data_type(),
-                        branch.clone(),
-                        (len.end - 1)..len.end,
-                        null.clone(),
-                        f.is_nullable,
-                    )
-                })
-                .collect(),
-        }),
-        DataType::List(field) => Box::new(ListSampler {
-            data_type: data_type.clone(),
-            len: len.clone(),
-            null: current_null,
-            inner: sampler_from_data_type(
-                field.data_type(),
-                branch.clone(),
-                (branch.start * len.start)..(branch.end * len.end),
-                null.clone(),
-                field.is_nullable,
-            ),
-        }),
-        dt => panic!("not implemented: {:?}", dt),
+    pub fn sampler_from_data_type(&self, data_type: &DataType) -> ArraySampler {
+        let current_null = if self.is_nullable {
+            Some(self.null.clone())
+        } else {
+            None
+        };
+        let len = self.len.clone();
+
+        match data_type {
+            DataType::Float32 => boxed_primitive(valid_f32(), len, current_null),
+            DataType::Float64 => boxed_primitive(valid_f64(), len, current_null),
+            DataType::Int8 => arbitrary_boxed_primitive::<i8, _>(len, current_null),
+            DataType::Int16 => arbitrary_boxed_primitive::<i16, _>(len, current_null),
+            DataType::Int32 => arbitrary_boxed_primitive::<i32, _>(len, current_null),
+            DataType::Int64 => arbitrary_boxed_primitive::<i64, _>(len, current_null),
+            DataType::UInt8 => arbitrary_boxed_primitive::<u8, _>(len, current_null),
+            DataType::UInt16 => arbitrary_boxed_primitive::<u16, _>(len, current_null),
+            DataType::UInt32 => arbitrary_boxed_primitive::<u32, _>(len, current_null),
+            DataType::UInt64 => arbitrary_boxed_primitive::<u64, _>(len, current_null),
+            DataType::Struct(fields) => Box::new(StructSampler {
+                data_type: data_type.clone(),
+                null: current_null,
+                values: fields
+                    .iter()
+                    .map(|f| {
+                        ArbitraryArray {
+                            len: (len.end - 1)..len.end,
+                            is_nullable: f.is_nullable,
+                            ..self.clone()
+                        }
+                        .sampler_from_data_type(f.data_type())
+                    })
+                    .collect(),
+            }),
+            DataType::List(field) => Box::new(ListSampler {
+                data_type: data_type.clone(),
+                len: len.clone(),
+                null: current_null,
+                inner: ArbitraryArray {
+                    branch: (self.branch.start * self.len.start)..(self.branch.end * self.len.end),
+                    is_nullable: field.is_nullable,
+                    ..self.clone()
+                }
+                .sampler_from_data_type(field.data_type()),
+            }),
+            dt => panic!("not implemented: {:?}", dt),
+        }
     }
 }

--- a/sample-arrow2/src/chunk.rs
+++ b/sample-arrow2/src/chunk.rs
@@ -1,18 +1,77 @@
 use std::ops::Range;
 
-use arrow2::{array::Array, chunk::Chunk};
-use sample_std::{Sample, VecSampler};
+use arrow2::{array::Array, chunk::Chunk, datatypes::DataType};
+use sample_std::{sample_all, Chained, Sample, VecSampler};
 
-use crate::array::ArraySampler;
+use crate::{array::ArbitraryArray, datatypes::DataTypeSampler};
 
-pub type ChunkSampler = Box<dyn Sample<Output = Chunk<Box<dyn Array>>> + Send + Sync>;
+pub type ChainedChunk = Chained<(Vec<DataType>, usize), Chunk<Box<dyn Array>>>;
+pub type ChunkSampler = Box<dyn Sample<Output = ChainedChunk> + Send + Sync>;
 
-pub fn sample_chunk(count: Range<usize>, array: ArraySampler) -> ChunkSampler {
-    Box::new(
-        VecSampler {
-            length: count,
-            el: array,
-        }
-        .wrap(|chunk| std::iter::once(chunk.to_vec()), Chunk::new),
-    )
+pub type ChainedMultiChunk = Chained<(Vec<DataType>, Vec<usize>), Vec<Chunk<Box<dyn Array>>>>;
+pub type MultiChunkSampler = Box<dyn Sample<Output = ChainedMultiChunk> + Send + Sync>;
+
+pub struct ArbitraryChunk<N, V> {
+    pub chunk_len: Range<usize>,
+    pub array_count: Range<usize>,
+    pub data_type: DataTypeSampler,
+    pub array: ArbitraryArray<N, V>,
+}
+
+impl<N, V> ArbitraryChunk<N, V>
+where
+    N: Sample<Output = String> + Send + Sync + Clone + 'static,
+    V: Sample<Output = bool> + Send + Sync + Clone + 'static,
+{
+    pub fn sample_one(self) -> ChunkSampler {
+        Box::new(
+            VecSampler {
+                length: self.array_count,
+                el: self.data_type,
+            }
+            .zip(self.chunk_len)
+            .chain_resample(move |seed| Self::from_seed(&self.array, seed), 100),
+        )
+    }
+
+    pub fn sample_many(self, chunk_count: Range<usize>) -> MultiChunkSampler {
+        Box::new(
+            VecSampler {
+                length: self.array_count,
+                el: self.data_type,
+            }
+            .zip(VecSampler {
+                length: chunk_count,
+                el: self.chunk_len,
+            })
+            .chain_resample(
+                move |(dts, lens)| {
+                    sample_all(
+                        lens.into_iter()
+                            .map(|len| Self::from_seed(&self.array, (dts.clone(), len)))
+                            .collect(),
+                    )
+                },
+                100,
+            ),
+        )
+    }
+
+    pub fn from_seed(
+        array: &ArbitraryArray<N, V>,
+        seed: (Vec<DataType>, usize),
+    ) -> Box<dyn Sample<Output = Chunk<Box<dyn Array>>> + Send + Sync> {
+        let (dts, len) = seed;
+        Box::new(
+            sample_all(
+                dts.into_iter()
+                    .map(|data_type| array.with_len(len).sampler_from_data_type(&data_type))
+                    .collect(),
+            )
+            .wrap(
+                |chunk| Box::new(std::iter::once(chunk.to_vec())),
+                Chunk::new,
+            ),
+        )
+    }
 }

--- a/sample-arrow2/src/chunk.rs
+++ b/sample-arrow2/src/chunk.rs
@@ -1,0 +1,18 @@
+use std::ops::Range;
+
+use arrow2::{array::Array, chunk::Chunk};
+use sample_std::{Sample, VecSampler};
+
+use crate::array::ArraySampler;
+
+pub type ChunkSampler = Box<dyn Sample<Output = Chunk<Box<dyn Array>>> + Send + Sync>;
+
+pub fn sample_chunk(count: Range<usize>, array: ArraySampler) -> ChunkSampler {
+    Box::new(
+        VecSampler {
+            length: count,
+            el: array,
+        }
+        .wrap(|chunk| std::iter::once(chunk.to_vec()), Chunk::new),
+    )
+}

--- a/sample-arrow2/src/datatypes.rs
+++ b/sample-arrow2/src/datatypes.rs
@@ -1,0 +1,100 @@
+use arrow2::datatypes::{DataType, Field};
+use sample_std::{choice, Always, Random, Sample, VecSampler};
+
+pub type DataTypeSampler = Box<dyn Sample<Output = DataType> + Send + Sync>;
+
+struct FieldSampler<N, V> {
+    names: N,
+    nullable: V,
+    inner: DataTypeSampler,
+}
+
+impl<N, V> Sample for FieldSampler<N, V>
+where
+    N: Sample<Output = String>,
+    V: Sample<Output = bool>,
+{
+    type Output = Field;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        Field::new(
+            self.names.generate(g),
+            self.inner.generate(g),
+            self.nullable.generate(g),
+        )
+    }
+}
+
+struct StructDataTypeSampler<S, F> {
+    size: S,
+    field: F,
+}
+
+impl<S, F> Sample for StructDataTypeSampler<S, F>
+where
+    S: Sample<Output = usize>,
+    F: Sample<Output = Field>,
+{
+    type Output = DataType;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        let size = self.size.generate(g);
+        DataType::Struct((0..size).map(|_| self.field.generate(g)).collect())
+    }
+}
+
+pub fn sample_flat() -> DataTypeSampler {
+    Box::new(choice([
+        Always(DataType::Float32),
+        Always(DataType::Float64),
+        Always(DataType::Int8),
+        Always(DataType::Int16),
+        Always(DataType::Int32),
+        Always(DataType::Int64),
+        Always(DataType::UInt8),
+        Always(DataType::UInt16),
+        Always(DataType::UInt32),
+        Always(DataType::UInt64),
+    ]))
+}
+
+pub fn sample_nested<N, V, F>(names: N, nullable: V, inner: F) -> DataTypeSampler
+where
+    N: Sample<Output = String> + Clone + Send + Sync + 'static,
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+    F: Fn() -> DataTypeSampler,
+{
+    let field = || FieldSampler {
+        names: names.clone(),
+        nullable: nullable.clone(),
+        inner: inner(),
+    };
+    Box::new(choice([
+        Box::new(sample_flat()) as DataTypeSampler,
+        Box::new(
+            VecSampler {
+                length: 1..4,
+                el: field(),
+            }
+            .wrap(|_| std::iter::empty(), DataType::Struct),
+        ),
+        Box::new(field().wrap(|_| std::iter::empty(), |f| DataType::List(Box::new(f)))),
+    ]))
+}
+
+pub fn sample_data_type<N, V>(depth: usize, names: N, nullable: V) -> DataTypeSampler
+where
+    N: Sample<Output = String> + Clone + Send + Sync + 'static,
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    let flats = sample_flat();
+    if depth == 0 {
+        flats
+    } else {
+        let inner = || sample_data_type(depth - 1, names.clone(), nullable.clone());
+        Box::new(choice([
+            sample_nested(names.clone(), nullable.clone(), inner),
+            flats,
+        ]))
+    }
+}

--- a/sample-arrow2/src/lib.rs
+++ b/sample-arrow2/src/lib.rs
@@ -1,0 +1,14 @@
+use arrow2::array::Array;
+use sample_std::Sample;
+
+pub mod array;
+pub mod chunk;
+pub mod datatypes;
+pub mod list;
+pub mod primitive;
+pub mod struct_;
+pub mod validity;
+
+pub use validity::{AlwaysValid, GenerateValidity, RandomValidity};
+
+pub type ArrowSampler = Box<dyn Sample<Output = Box<dyn Array>> + Send + Sync>;

--- a/sample-arrow2/src/list.rs
+++ b/sample-arrow2/src/list.rs
@@ -1,0 +1,53 @@
+use std::ops::Range;
+
+use crate::{array::ArraySampler, validity::generate_validity};
+use arrow2::{
+    array::{Array, ListArray},
+    datatypes::DataType,
+    offset::OffsetsBuffer,
+};
+use sample_std::{Random, Sample};
+
+pub struct ListSampler<V> {
+    pub data_type: DataType,
+    pub null: Option<V>,
+    pub len: Range<usize>,
+    pub inner: ArraySampler,
+}
+
+impl<V> Sample for ListSampler<V>
+where
+    V: Sample<Output = bool> + Send + Sync + 'static,
+{
+    type Output = Box<dyn Array>;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        let values = self.inner.generate(g);
+        let len = self.len.generate(g);
+        let mut ix = 0;
+        let mut offsets = vec![0];
+
+        for outer_ix in 0..len {
+            if outer_ix + 1 != len {
+                let remaining = values.len() - ix;
+                let fair = std::cmp::max(2, remaining / (len - outer_ix));
+                let upper = std::cmp::min(values.len() - ix, fair);
+                let count = g.gen_range(0..=upper);
+                ix += count;
+                offsets.push(ix as i32);
+            } else {
+                offsets.push(values.len() as i32);
+            }
+        }
+
+        let validity = generate_validity(&self.null, g, len);
+
+        ListArray::new(
+            self.data_type.clone(),
+            OffsetsBuffer::try_from(offsets).unwrap(),
+            values,
+            validity,
+        )
+        .boxed()
+    }
+}

--- a/sample-arrow2/src/primitive.rs
+++ b/sample-arrow2/src/primitive.rs
@@ -1,0 +1,268 @@
+use std::ops::Range;
+
+use arrow2::{
+    array::{Array, PrimitiveArray},
+    types::NativeType,
+};
+use sample_std::{
+    arbitrary, choice, valid_f32, valid_f64, Arbitrary, ArbitrarySampler, Random, Sample, Shrunk,
+    VecSampler,
+};
+
+use crate::ArrowSampler;
+
+#[derive(Debug, Clone)]
+pub struct ProtoNullablePrimitiveArray<PT> {
+    inner: VecSampler<Range<usize>, PT>,
+}
+
+fn to_primitive<T>(vec: Vec<Option<T>>) -> PrimitiveArray<T>
+where
+    T: NativeType + Arbitrary,
+{
+    PrimitiveArray::from_trusted_len_iter(vec.into_iter())
+}
+
+impl<PT, T> Sample for ProtoNullablePrimitiveArray<PT>
+where
+    PT: Sample<Output = Option<T>> + Clone + 'static,
+    T: NativeType + Arbitrary,
+{
+    type Output = PrimitiveArray<T>;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        to_primitive(self.inner.generate(g))
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<Self::Output> {
+        let vec = v.iter().map(|el| el.cloned()).collect();
+        Box::new(self.inner.shrink(vec).map(to_primitive))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProtoPrimitiveArray<PT> {
+    inner: VecSampler<Range<usize>, PT>,
+}
+
+impl<PT, T> Sample for ProtoPrimitiveArray<PT>
+where
+    PT: Sample<Output = T> + Clone + 'static,
+    T: NativeType,
+{
+    type Output = PrimitiveArray<T>;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        PrimitiveArray::from_trusted_len_values_iter(self.inner.generate(g).into_iter())
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<Self::Output> {
+        let vec = v.values_iter().cloned().collect();
+        Box::new(
+            self.inner
+                .shrink(vec)
+                .map(IntoIterator::into_iter)
+                .map(PrimitiveArray::from_trusted_len_values_iter),
+        )
+    }
+}
+
+pub fn boxed_nullable<GT, T>(len: Range<usize>, el: GT) -> ArrowSampler
+where
+    GT: Sample<Output = Option<T>> + Send + Sync + Clone + 'static,
+    T: NativeType + Arbitrary,
+{
+    Box::new(ProtoBoxedNullablePrimitiveArray {
+        inner: ProtoNullablePrimitiveArray {
+            inner: VecSampler { length: len, el },
+        },
+    })
+}
+
+pub fn boxed<GT, T>(len: Range<usize>, el: GT) -> ArrowSampler
+where
+    GT: Sample<Output = T> + Send + Sync + Clone + 'static,
+    T: NativeType + Arbitrary,
+{
+    Box::new(
+        ProtoPrimitiveArray {
+            inner: VecSampler { length: len, el },
+        }
+        .wrap(
+            |boxed| {
+                if boxed.validity().is_none() {
+                    boxed.as_any().downcast_ref::<PrimitiveArray<T>>().cloned()
+                } else {
+                    None
+                }
+            },
+            PrimitiveArray::boxed,
+        ),
+    )
+}
+
+#[derive(Clone)]
+pub struct ProtoBoxedNullablePrimitiveArray<PT> {
+    inner: ProtoNullablePrimitiveArray<PT>,
+}
+
+impl<GT, T> Sample for ProtoBoxedNullablePrimitiveArray<GT>
+where
+    GT: Sample<Output = Option<T>> + Clone + 'static,
+    T: NativeType + Arbitrary,
+{
+    type Output = Box<dyn Array>;
+
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        self.inner.generate(g).boxed()
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(
+            v.as_any()
+                .downcast_ref::<PrimitiveArray<T>>()
+                .cloned()
+                .into_iter()
+                .flat_map(move |arr| self.inner.shrink(arr.clone()).map(|arr| arr.boxed())),
+        )
+    }
+}
+
+#[derive(Clone)]
+struct Nullable<SI, V> {
+    inner: SI,
+    null: V,
+}
+
+impl<SI, V> Sample for Nullable<SI, V>
+where
+    SI: Sample,
+    V: Sample<Output = bool>,
+{
+    type Output = Option<SI::Output>;
+    fn generate(&self, g: &mut Random) -> Self::Output {
+        if self.null.generate(g) {
+            None
+        } else {
+            Some(self.inner.generate(g))
+        }
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<Self::Output> {
+        if let Some(v) = v {
+            Box::new(std::iter::once(None).chain(self.inner.shrink(v).map(Some)))
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+}
+
+pub fn boxed_primitive<T, V>(
+    el: ArbitrarySampler<T>,
+    len: Range<usize>,
+    null: Option<V>,
+) -> ArrowSampler
+where
+    T: Arbitrary + NativeType,
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    match null {
+        Some(null) => boxed_nullable(len.clone(), Nullable { inner: el, null }),
+        None => boxed(len.clone(), el),
+    }
+}
+
+pub fn arbitrary_boxed_primitive<T, V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+    T: NativeType + Arbitrary,
+{
+    boxed_primitive(arbitrary::<T>(), len, null)
+}
+
+// todo: arbitrary_daysms_array
+
+pub fn valid_float_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(choice(vec![
+        // todo: f16
+        boxed_primitive(valid_f32(), len.clone(), null.clone()),
+        boxed_primitive(valid_f64(), len, null),
+    ]))
+}
+
+pub fn arbitrary_float_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(choice(vec![
+        // todo: f16
+        arbitrary_boxed_primitive::<f32, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<f32, _>(len, null),
+    ]))
+}
+
+pub fn arbitrary_int_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(choice(vec![
+        arbitrary_boxed_primitive::<i8, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<i16, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<i32, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<i64, _>(len.clone(), null.clone()),
+    ]))
+}
+
+// todo: arbitrary_monthsdaysnano_array
+
+pub fn arbitrary_uint_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(choice(vec![
+        arbitrary_boxed_primitive::<u8, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<u16, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<u32, _>(len.clone(), null.clone()),
+        arbitrary_boxed_primitive::<u64, _>(len.clone(), null.clone()),
+    ]))
+}
+
+pub fn valid_primitive<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(choice([
+        valid_float_array(len.clone(), null.clone()),
+        arbitrary_int_array(len.clone(), null.clone()),
+        arbitrary_uint_array(len.clone(), null.clone()),
+    ]))
+}
+
+pub fn arbitrary_primitive<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(choice([
+        arbitrary_float_array(len.clone(), null.clone()),
+        arbitrary_int_array(len.clone(), null.clone()),
+        arbitrary_uint_array(len.clone(), null.clone()),
+    ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use sample_std::Chance;
+
+    use super::*;
+
+    #[test]
+    fn gen_float() {
+        let gen = valid_float_array(50..51, Some(Chance(0.5)));
+        let mut r = Random::new(100);
+        let arr = gen.generate(&mut r);
+        assert_eq!(arr, arr);
+    }
+}

--- a/sample-arrow2/src/validity.rs
+++ b/sample-arrow2/src/validity.rs
@@ -1,0 +1,53 @@
+use arrow2::bitmap::Bitmap;
+use sample_std::{Random, Sample};
+
+pub trait GenerateValidity {
+    fn generate_validity(&self, g: &mut Random, len: usize) -> Option<Bitmap>;
+    fn generate_valid(&self, g: &mut Random) -> bool;
+}
+
+#[derive(Debug, Clone)]
+pub struct AlwaysValid;
+
+impl GenerateValidity for AlwaysValid {
+    fn generate_validity(&self, _: &mut Random, _: usize) -> Option<Bitmap> {
+        None
+    }
+
+    fn generate_valid(&self, _: &mut Random) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RandomValidity {
+    pub null_chance: f64,
+    pub nullable_chance: f64,
+}
+
+pub fn generate_validity<V>(null: &Option<V>, g: &mut Random, len: usize) -> Option<Bitmap>
+where
+    V: Sample<Output = bool>,
+{
+    null.as_ref().map(|null| {
+        Bitmap::from_trusted_len_iter(std::iter::repeat(()).take(len).map(|_| !null.generate(g)))
+    })
+}
+
+impl GenerateValidity for RandomValidity {
+    fn generate_validity(&self, g: &mut Random, len: usize) -> Option<Bitmap> {
+        if g.gen_range(0.0..1.0) < self.nullable_chance {
+            Some(Bitmap::from_trusted_len_iter(
+                std::iter::repeat(())
+                    .take(len)
+                    .map(|_| self.generate_valid(g)),
+            ))
+        } else {
+            None
+        }
+    }
+
+    fn generate_valid(&self, g: &mut Random) -> bool {
+        g.gen_range(0.0..1.0) > self.null_chance
+    }
+}

--- a/sample-arrow2/tests/array.rs
+++ b/sample-arrow2/tests/array.rs
@@ -1,32 +1,41 @@
-use arrow2::array::Array;
+use arrow2::{array::Array, datatypes::DataType};
 use sample_arrow2::{
-    array::{ArbitrarySampler, ArraySampler},
-    ArrowSampler,
+    array::{ArbitraryArray, ChainedArraySampler},
+    datatypes::{sample_flat, ArbitraryDataType},
 };
-use sample_std::{Chance, Regex};
+use sample_std::{Chained, Chance, Regex};
 use sample_test::{lazy_static, sample_test};
 use std::boxed::Box;
 
-fn deep_array(depth: usize) -> ArraySampler {
-    Box::new(ArbitrarySampler {
-        data_type_depth: depth,
-        names: Regex::new("[a-z]{4,8}"),
+fn deep_array(depth: usize) -> ChainedArraySampler {
+    let names = Regex::new("[a-z]{4,8}");
+    let dt = ArbitraryDataType {
+        struct_branch: 1..3,
+        names: names.clone(),
         nullable: Chance(0.5),
+        flat: sample_flat,
+    }
+    .sample_depth(depth);
 
-        branch: 0..10,
-        len: 10..11,
-        null: Chance(0.1),
-        is_nullable: true,
-    })
+    Box::new(
+        ArbitraryArray {
+            names,
+            branch: 0..10,
+            len: 10..11,
+            null: Chance(0.1),
+            is_nullable: true,
+        }
+        .arbitrary_array(dt),
+    )
 }
 
 lazy_static! {
-    static ref DEEP_LIST: ArrowSampler = deep_array(3);
+    static ref DEEP_LIST: ChainedArraySampler = deep_array(3);
 }
 
 #[sample_test]
-fn list_equality(#[sample(DEEP_LIST)] list: Box<dyn Array>) {
-    let mut list = list.clone();
+fn list_equality(#[sample(DEEP_LIST)] list: Chained<DataType, Box<dyn Array>>) {
+    let mut list = list.value.clone();
     assert_eq!(list.len(), 10);
     assert_eq!(list, list);
     if list.len() > 2 {

--- a/sample-arrow2/tests/array.rs
+++ b/sample-arrow2/tests/array.rs
@@ -1,0 +1,37 @@
+use arrow2::array::Array;
+use sample_arrow2::{
+    array::{ArbitrarySampler, ArraySampler},
+    ArrowSampler,
+};
+use sample_std::{Chance, Regex};
+use sample_test::{lazy_static, sample_test};
+use std::boxed::Box;
+
+fn deep_array(depth: usize) -> ArraySampler {
+    Box::new(ArbitrarySampler {
+        data_type_depth: depth,
+        names: Regex::new("[a-z]{4,8}"),
+        nullable: Chance(0.5),
+
+        branch: 0..10,
+        len: 10..11,
+        null: Chance(0.1),
+        is_nullable: true,
+    })
+}
+
+lazy_static! {
+    static ref DEEP_LIST: ArrowSampler = deep_array(3);
+}
+
+#[sample_test]
+fn list_equality(#[sample(DEEP_LIST)] list: Box<dyn Array>) {
+    let mut list = list.clone();
+    assert_eq!(list.len(), 10);
+    assert_eq!(list, list);
+    if list.len() > 2 {
+        let before = list.clone();
+        list.slice(0, list.len() / 2);
+        assert_ne!(before, list);
+    }
+}

--- a/sample-arrow2/tests/chunk.rs
+++ b/sample-arrow2/tests/chunk.rs
@@ -1,30 +1,51 @@
-use arrow2::{array::Array, chunk::Chunk};
 use sample_arrow2::{
-    array::{ArbitrarySampler, ArraySampler},
-    chunk::{sample_chunk, ChunkSampler},
+    array::ArbitraryArray,
+    chunk::{ArbitraryChunk, ChainedChunk, ChainedMultiChunk, ChunkSampler, MultiChunkSampler},
+    datatypes::{sample_flat, ArbitraryDataType},
 };
 use sample_std::{Chance, Regex};
 use sample_test::{lazy_static, sample_test};
 use std::boxed::Box;
 
-fn deep_array(len: usize, depth: usize) -> ArraySampler {
-    Box::new(ArbitrarySampler {
-        data_type_depth: depth,
-        names: Regex::new("[a-z]{4,8}"),
+fn deep_chunk(depth: usize, len: usize) -> ArbitraryChunk<Regex, Chance> {
+    let names = Regex::new("[a-z]{4,8}");
+    let data_type = ArbitraryDataType {
+        struct_branch: 1..3,
+        names: names.clone(),
         nullable: Chance(0.5),
+        flat: sample_flat,
+    }
+    .sample_depth(depth);
 
+    let array = ArbitraryArray {
+        names,
         branch: 0..10,
         len: len..(len + 1),
         null: Chance(0.1),
         is_nullable: true,
-    })
+    };
+
+    ArbitraryChunk {
+        chunk_len: 10..100,
+        array_count: 4..6,
+        data_type,
+        array,
+    }
 }
 
 lazy_static! {
-    static ref DEEP_CHUNK: ChunkSampler = sample_chunk(4..6, deep_array(100, 3));
+    static ref DEEP_CHUNK: ChunkSampler = deep_chunk(3, 100).sample_one();
+    static ref MANY_DEEP_CHUNK: MultiChunkSampler = deep_chunk(3, 100).sample_many(2..10);
 }
 
 #[sample_test]
-fn arbitrary_chunk(#[sample(DEEP_CHUNK)] chunk: Chunk<Box<dyn Array>>) {
+fn arbitrary_chunk(#[sample(DEEP_CHUNK)] chunk: ChainedChunk) {
+    let chunk = chunk.value;
+    assert_eq!(chunk, chunk);
+}
+
+#[sample_test]
+fn arbitrary_chunks(#[sample(MANY_DEEP_CHUNK)] chunk: ChainedMultiChunk) {
+    let chunk = chunk.value;
     assert_eq!(chunk, chunk);
 }

--- a/sample-arrow2/tests/chunk.rs
+++ b/sample-arrow2/tests/chunk.rs
@@ -1,0 +1,30 @@
+use arrow2::{array::Array, chunk::Chunk};
+use sample_arrow2::{
+    array::{ArbitrarySampler, ArraySampler},
+    chunk::{sample_chunk, ChunkSampler},
+};
+use sample_std::{Chance, Regex};
+use sample_test::{lazy_static, sample_test};
+use std::boxed::Box;
+
+fn deep_array(len: usize, depth: usize) -> ArraySampler {
+    Box::new(ArbitrarySampler {
+        data_type_depth: depth,
+        names: Regex::new("[a-z]{4,8}"),
+        nullable: Chance(0.5),
+
+        branch: 0..10,
+        len: len..(len + 1),
+        null: Chance(0.1),
+        is_nullable: true,
+    })
+}
+
+lazy_static! {
+    static ref DEEP_CHUNK: ChunkSampler = sample_chunk(4..6, deep_array(100, 3));
+}
+
+#[sample_test]
+fn arbitrary_chunk(#[sample(DEEP_CHUNK)] chunk: Chunk<Box<dyn Array>>) {
+    assert_eq!(chunk, chunk);
+}


### PR DESCRIPTION
This makes heavy use of chained resampling. Unfortunately properly shrinking sampled arrow values just feels like a hard problem.

The core issue is the length for every array in a chunk must be the same, and the length is also influenced by the datatype (e.g. typical nested arrays have a larger inner array than primitive or struct arrays). Thus, some form of chaining (generate datatype+length, then generate arrays) is essentially required.

One nice thing about this implementation is that we can use an existing datatype (e.g. from a particular model) to sample arbitrary data that matches that type. Could be good for fuzz testing, possibly in connection with the ONNX model zoo.

That's all pretty pie in the sky though.