### PR TITLE
Add SampleTest and update macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,14 @@ edition = "2021"
 members = ["sample-std", "sample-test-macros", "sample-arrow2"]
 
 [dependencies]
-lazy_static = "1.4"
+log = { version = "0.4", optional = true }
+env_logger = { version = "0.10", optional = true }
 quickcheck="1.0"
 sample-std = { path = "sample-std" }
 sample-test-macros = { path = "sample-test-macros" }
+
+[dev-dependencies]
+once_cell = "1.0"
+
+[features]
+use_logging = ["dep:log", "dep:env_logger"]

--- a/sample-arrow2/tests/array.rs
+++ b/sample-arrow2/tests/array.rs
@@ -4,7 +4,7 @@ use sample_arrow2::{
     datatypes::{sample_flat, ArbitraryDataType},
 };
 use sample_std::{Chained, Chance, Regex};
-use sample_test::{lazy_static, sample_test};
+use sample_test::sample_test;
 use std::boxed::Box;
 
 fn deep_array(depth: usize) -> ChainedArraySampler {
@@ -29,12 +29,8 @@ fn deep_array(depth: usize) -> ChainedArraySampler {
     )
 }
 
-lazy_static! {
-    static ref DEEP_LIST: ChainedArraySampler = deep_array(3);
-}
-
 #[sample_test]
-fn list_equality(#[sample(DEEP_LIST)] list: Chained<DataType, Box<dyn Array>>) {
+fn list_equality(#[sample(deep_array(3))] list: Chained<DataType, Box<dyn Array>>) {
     let mut list = list.value.clone();
     assert_eq!(list.len(), 10);
     assert_eq!(list, list);

--- a/sample-arrow2/tests/chunk.rs
+++ b/sample-arrow2/tests/chunk.rs
@@ -1,11 +1,10 @@
 use sample_arrow2::{
     array::ArbitraryArray,
-    chunk::{ArbitraryChunk, ChainedChunk, ChainedMultiChunk, ChunkSampler, MultiChunkSampler},
+    chunk::{ArbitraryChunk, ChainedChunk, ChainedMultiChunk},
     datatypes::{sample_flat, ArbitraryDataType},
 };
 use sample_std::{Chance, Regex};
-use sample_test::{lazy_static, sample_test};
-use std::boxed::Box;
+use sample_test::sample_test;
 
 fn deep_chunk(depth: usize, len: usize) -> ArbitraryChunk<Regex, Chance> {
     let names = Regex::new("[a-z]{4,8}");
@@ -33,19 +32,14 @@ fn deep_chunk(depth: usize, len: usize) -> ArbitraryChunk<Regex, Chance> {
     }
 }
 
-lazy_static! {
-    static ref DEEP_CHUNK: ChunkSampler = deep_chunk(3, 100).sample_one();
-    static ref MANY_DEEP_CHUNK: MultiChunkSampler = deep_chunk(3, 100).sample_many(2..10);
-}
-
 #[sample_test]
-fn arbitrary_chunk(#[sample(DEEP_CHUNK)] chunk: ChainedChunk) {
+fn arbitrary_chunk(#[sample(deep_chunk(3, 100).sample_one())] chunk: ChainedChunk) {
     let chunk = chunk.value;
     assert_eq!(chunk, chunk);
 }
 
 #[sample_test]
-fn arbitrary_chunks(#[sample(MANY_DEEP_CHUNK)] chunk: ChainedMultiChunk) {
+fn arbitrary_chunks(#[sample(deep_chunk(3, 100).sample_many(2..10))] chunk: ChainedMultiChunk) {
     let chunk = chunk.value;
     assert_eq!(chunk, chunk);
 }

--- a/sample-std/Cargo.toml
+++ b/sample-std/Cargo.toml
@@ -15,4 +15,5 @@ regex = "1.8"
 casey = "0.4"
 
 [dev-dependencies]
+once_cell = "1.0"
 sample-test = { path = "..",  version = "0.1.0" }

--- a/sample-std/src/lib.rs
+++ b/sample-std/src/lib.rs
@@ -502,7 +502,10 @@ where
 
     fn shrink(&self, v: Self::Output) -> Shrunk<'_, Self::Output> {
         if self.start != v {
-            Box::new((self.start.clone()..v.clone()).into_iter().rev().take(1))
+            Box::new(
+                std::iter::once(self.start.clone())
+                    .chain((self.start.clone()..v.clone()).into_iter().rev().take(1)),
+            )
         } else {
             Box::new(std::iter::empty())
         }

--- a/sample-test-macros/Cargo.toml
+++ b/sample-test-macros/Cargo.toml
@@ -11,12 +11,12 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-lazy_static = "1.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 sample-std = { path = "../sample-std" }
 syn = { version = "1.0", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-quickcheck = "1.0"
+once_cell = "1.0"
+lazy_static = "1.4"
 sample-test = { path = ".." }

--- a/sample-test-macros/tests/macro.rs
+++ b/sample-test-macros/tests/macro.rs
@@ -1,13 +1,30 @@
+use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
+use sample_test::sample_test;
 use sample_test::TestResult;
-use sample_test::{lazy_static, sample_test};
 use std::ops::Range;
 
 lazy_static! {
     static ref RANGE: Range<usize> = 10..20;
 }
 
+static RANGE2: Lazy<Range<usize>> = Lazy::new(|| 10..20);
+
+fn range() -> Range<usize> {
+    10..20
+}
+
 #[sample_test]
-fn min(#[sample(RANGE)] x: usize, #[sample(RANGE)] y: usize) -> TestResult {
+fn min(#[sample(10..20)] x: usize, #[sample(range())] y: usize) -> TestResult {
+    if x < y {
+        TestResult::discard()
+    } else {
+        TestResult::from_bool(::std::cmp::min(x, y) == y)
+    }
+}
+
+#[sample_test]
+fn min2(#[sample(RANGE.clone())] x: usize, #[sample(RANGE2.clone())] y: usize) -> TestResult {
     if x < y {
         TestResult::discard()
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,55 @@
-pub use lazy_static::lazy_static;
 pub use sample_test_macros::sample_test;
 
-pub use quickcheck::{Arbitrary, Gen, TestResult, Testable};
+pub use quickcheck::{Arbitrary, Gen};
+
+pub mod tester;
+
+pub use tester::{SampleTest, TestResult, Testable};
+
+#[cfg(feature = "use_logging")]
+pub fn env_logger_init() -> Result<(), log::SetLoggerError> {
+    env_logger::try_init()
+}
+#[cfg(feature = "use_logging")]
+macro_rules! error {
+    ($($tt:tt)*) => {
+        log::error!($($tt)*)
+    };
+}
+#[cfg(feature = "use_logging")]
+macro_rules! info {
+    ($($tt:tt)*) => {
+        log::info!($($tt)*)
+    };
+}
+#[cfg(feature = "use_logging")]
+macro_rules! trace {
+    ($($tt:tt)*) => {
+        log::trace!($($tt)*)
+    };
+}
+
+#[cfg(not(feature = "use_logging"))]
+pub fn env_logger_init() {}
+#[cfg(not(feature = "use_logging"))]
+macro_rules! error {
+    ($($_ignore:tt)*) => {
+        ()
+    };
+}
+#[cfg(not(feature = "use_logging"))]
+macro_rules! info {
+    ($($_ignore:tt)*) => {
+        ()
+    };
+}
+#[cfg(not(feature = "use_logging"))]
+macro_rules! trace {
+    ($($_ignore:tt)*) => {
+        ()
+    };
+}
+
+pub(crate) use error;
+pub(crate) use info;
+pub(crate) use trace;

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -1,0 +1,446 @@
+use std::cmp;
+use std::env;
+use std::fmt::Debug;
+use std::panic;
+
+use sample_std::{Random, Sample};
+
+use crate::tester::Status::{Discard, Fail, Pass};
+use crate::{error, info, trace};
+
+/// The main [SampleTest] type for setting configuration and running sample-based testing.
+pub struct SampleTest {
+    tests: u64,
+    max_tests: u64,
+    min_tests_passed: u64,
+    gen: Random,
+}
+
+fn st_tests() -> u64 {
+    let default = 100;
+    match env::var("SAMPLE_TEST_TESTS") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
+fn st_max_tests() -> u64 {
+    let default = 10_000;
+    match env::var("SAMPLE_TEST_MAX_TESTS") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
+fn st_gen_size() -> usize {
+    let default = 100;
+    match env::var("SAMPLE_TEST_GENERATOR_SIZE") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
+fn st_min_tests_passed() -> u64 {
+    let default = 0;
+    match env::var("SAMPLE_TEST_MIN_TESTS_PASSED") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
+impl SampleTest {
+    /// Creates a new [SampleTest] value.
+    ///
+    /// This can be used to run [SampleTest] on things that implement [Testable].
+    /// You may also adjust the configuration, such as the number of tests to
+    /// run.
+    ///
+    /// By default, the maximum number of passed tests is set to `100`, the max
+    /// number of overall tests is set to `10000` and the generator is created
+    /// with a size of `100`.
+    pub fn new() -> SampleTest {
+        let gen = Random::new(st_gen_size());
+        let tests = st_tests();
+        let max_tests = cmp::max(tests, st_max_tests());
+        let min_tests_passed = st_min_tests_passed();
+
+        SampleTest {
+            tests,
+            max_tests,
+            min_tests_passed,
+            gen,
+        }
+    }
+
+    /// Set the number of tests to run.
+    ///
+    /// This actually refers to the maximum number of *passed* tests that
+    /// can occur. Namely, if a test causes a failure, future testing on that
+    /// property stops. Additionally, if tests are discarded, there may be
+    /// fewer than `tests` passed.
+    pub fn tests(mut self, tests: u64) -> SampleTest {
+        self.tests = tests;
+        self
+    }
+
+    /// Set the maximum number of tests to run.
+    ///
+    /// The number of invocations of a property will never exceed this number.
+    /// This is necessary to cap the number of tests because [SampleTest]
+    /// properties can discard tests.
+    pub fn max_tests(mut self, max_tests: u64) -> SampleTest {
+        self.max_tests = max_tests;
+        self
+    }
+
+    /// Set the minimum number of tests that needs to pass.
+    ///
+    /// This actually refers to the minimum number of *valid* *passed* tests
+    /// that needs to pass for the property to be considered successful.
+    pub fn min_tests_passed(mut self, min_tests_passed: u64) -> SampleTest {
+        self.min_tests_passed = min_tests_passed;
+        self
+    }
+
+    /// Tests a property and returns the result.
+    ///
+    /// The result returned is either the number of tests passed or a witness
+    /// of failure.
+    ///
+    /// (If you're using Rust's unit testing infrastructure, then you'll
+    /// want to use the `sample_test` method, which will `panic!` on failure.)
+    pub fn sample_test_count<S, A>(&mut self, s: S, f: A) -> Result<u64, TestResult>
+    where
+        A: Testable<S>,
+        S: Sample,
+        S::Output: Clone + Debug,
+    {
+        let mut n_tests_passed = 0;
+        for _ in 0..self.max_tests {
+            if n_tests_passed >= self.tests {
+                break;
+            }
+            match f.test_once(&s, &mut self.gen) {
+                TestResult { status: Pass, .. } => n_tests_passed += 1,
+                TestResult {
+                    status: Discard, ..
+                } => continue,
+                r @ TestResult { status: Fail, .. } => return Err(r),
+            }
+        }
+        Ok(n_tests_passed)
+    }
+
+    /// Tests a property and calls `panic!` on failure.
+    ///
+    /// The `panic!` message will include a (hopefully) minimal witness of
+    /// failure.
+    ///
+    /// It is appropriate to use this method with Rust's unit testing
+    /// infrastructure.
+    ///
+    /// Note that if the environment variable `RUST_LOG` is set to enable
+    /// `info` level log messages for the `sample_test` crate, then this will
+    /// include output on how many [SampleTest] tests were passed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use sample_test::{SampleTest};
+    /// use sample_std::VecSampler;
+    ///
+    /// fn prop_reverse_reverse() {
+    ///     fn revrev(xs: Vec<usize>) -> bool {
+    ///         let rev: Vec<_> = xs.clone().into_iter().rev().collect();
+    ///         let revrev: Vec<_> = rev.into_iter().rev().collect();
+    ///         xs == revrev
+    ///     }
+    ///     let sampler = (VecSampler { length: (0..20), el: (0..100usize) },);
+    ///     SampleTest::new().sample_test(sampler, revrev as fn(Vec<usize>) -> bool);
+    /// }
+    /// ```
+    pub fn sample_test<S, A>(&mut self, s: S, f: A)
+    where
+        A: Testable<S>,
+        S: Sample,
+        S::Output: Clone + Debug,
+    {
+        // Ignore log init failures, implying it has already been done.
+        let _ = crate::env_logger_init();
+
+        let n_tests_passed = match self.sample_test_count(s, f) {
+            Ok(n_tests_passed) => n_tests_passed,
+            Err(result) => panic!("{}", result.failed_msg()),
+        };
+
+        if n_tests_passed >= self.min_tests_passed {
+            info!("(Passed {} SampleTest tests.)", n_tests_passed)
+        } else {
+            panic!(
+                "(Unable to generate enough tests, {} not discarded.)",
+                n_tests_passed
+            )
+        }
+    }
+}
+
+/// Convenience function for running [SampleTest].
+///
+/// This is an alias for `SampleTest::new().sample_test(f)`.
+pub fn sample_test<S, A>(s: S, f: A)
+where
+    A: Testable<S>,
+    S: Sample,
+    S::Output: Clone + Debug,
+{
+    SampleTest::new().sample_test(s, f)
+}
+
+/// Describes the status of a single instance of a test.
+///
+/// All testable things must be capable of producing a `TestResult`.
+#[derive(Clone, Debug)]
+pub struct TestResult {
+    status: Status,
+    arguments: String,
+    err: Option<String>,
+}
+
+/// Whether a test has passed, failed or been discarded.
+#[derive(Clone, Debug)]
+enum Status {
+    Pass,
+    Fail,
+    Discard,
+}
+
+impl TestResult {
+    /// Produces a test result that indicates the current test has passed.
+    pub fn passed() -> TestResult {
+        TestResult::from_bool(true)
+    }
+
+    /// Produces a test result that indicates the current test has failed.
+    pub fn failed() -> TestResult {
+        TestResult::from_bool(false)
+    }
+
+    /// Produces a test result that indicates failure from a runtime error.
+    pub fn error<S: Into<String>>(msg: S) -> TestResult {
+        let mut r = TestResult::from_bool(false);
+        r.err = Some(msg.into());
+        r
+    }
+
+    /// Produces a test result that instructs `sample_test` to ignore it.
+    /// This is useful for restricting the domain of your properties.
+    /// When a test is discarded, `sample_test` will replace it with a
+    /// fresh one (up to a certain limit).
+    pub fn discard() -> TestResult {
+        TestResult {
+            status: Discard,
+            arguments: String::from(""),
+            err: None,
+        }
+    }
+
+    /// Converts a `bool` to a `TestResult`. A `true` value indicates that
+    /// the test has passed and a `false` value indicates that the test
+    /// has failed.
+    pub fn from_bool(b: bool) -> TestResult {
+        TestResult {
+            status: if b { Pass } else { Fail },
+            arguments: String::from(""),
+            err: None,
+        }
+    }
+
+    /// Tests if a "procedure" fails when executed. The test passes only if
+    /// `f` generates a task failure during its execution.
+    pub fn must_fail<T, F>(f: F) -> TestResult
+    where
+        F: FnOnce() -> T,
+        F: 'static,
+        T: 'static,
+    {
+        let f = panic::AssertUnwindSafe(f);
+        TestResult::from_bool(panic::catch_unwind(f).is_err())
+    }
+
+    /// Returns `true` if and only if this test result describes a successful
+    /// test.
+    pub fn is_success(&self) -> bool {
+        match self.status {
+            Pass => true,
+            Fail | Discard => false,
+        }
+    }
+
+    /// Returns `true` if and only if this test result describes a failing
+    /// test.
+    pub fn is_failure(&self) -> bool {
+        match self.status {
+            Fail => true,
+            Pass | Discard => false,
+        }
+    }
+
+    /// Returns `true` if and only if this test result describes a failing
+    /// test as a result of a run time error.
+    pub fn is_error(&self) -> bool {
+        self.is_failure() && self.err.is_some()
+    }
+
+    pub fn arguments(&self) -> &str {
+        &self.arguments
+    }
+
+    fn failed_msg(&self) -> String {
+        match self.err {
+            None => format!("[sample_test] TEST FAILED. Arguments: ({})", self.arguments),
+            Some(ref err) => format!(
+                "[sample_test] TEST FAILED (runtime error). \
+                 Arguments: ({})\nError: {}",
+                self.arguments, err
+            ),
+        }
+    }
+}
+
+/// `Testable` describes types (e.g., a function) whose values can be
+/// tested.
+///
+/// Anything that can be tested must be capable of producing a [TestResult]
+/// from the output of an instance of [Sample].
+///
+/// It's unlikely that you'll have to implement this trait yourself.
+pub trait Testable<S>: 'static
+where
+    S: Sample,
+{
+    fn result(&self, v: S::Output) -> TestResult;
+
+    fn test_once(&self, s: &S, rng: &mut Random) -> TestResult
+    where
+        S::Output: Clone + Debug,
+    {
+        let v = Sample::generate(s, rng);
+        let r = self.result(v.clone());
+        match r.status {
+            Pass | Discard => r,
+            Fail => {
+                error!("{:?}", r);
+                self.shrink(s, r, v)
+            }
+        }
+    }
+
+    fn shrink(&self, s: &S, r: TestResult, v: S::Output) -> TestResult
+    where
+        S::Output: Clone + Debug,
+    {
+        trace!("shrinking {:?}", v);
+        let mut result = r;
+        let mut it = s.shrink(v);
+        let iterations = 10_000_000;
+
+        for _ in 0..iterations {
+            let sv = it.next();
+            if let Some(sv) = sv {
+                let r_new = self.result(sv.clone());
+                if r_new.is_failure() {
+                    trace!("shrinking {:?}", sv);
+                    result = r_new;
+                    it = s.shrink(sv);
+                }
+            } else {
+                return result;
+            }
+        }
+
+        trace!(
+            "halting shrinkage after {} iterations with: {:?}",
+            iterations,
+            result
+        );
+
+        result
+    }
+}
+
+impl From<bool> for TestResult {
+    fn from(value: bool) -> TestResult {
+        TestResult::from_bool(value)
+    }
+}
+
+impl From<()> for TestResult {
+    fn from(_: ()) -> TestResult {
+        TestResult::passed()
+    }
+}
+
+impl<A, E> From<Result<A, E>> for TestResult
+where
+    TestResult: From<A>,
+    E: Debug + 'static,
+{
+    fn from(value: Result<A, E>) -> TestResult {
+        match value {
+            Ok(r) => r.into(),
+            Err(err) => TestResult::error(format!("{:?}", err)),
+        }
+    }
+}
+
+macro_rules! testable_fn {
+    ($($name: ident),*) => {
+
+impl<T: 'static, S, $($name),*> Testable<S> for fn($($name),*) -> T
+where
+    TestResult: From<T>,
+    S: Sample<Output=($($name),*,)>,
+    ($($name),*,): Clone,
+    $($name: Debug + 'static),*
+{
+    #[allow(non_snake_case)]
+    fn result(&self, v: S::Output) -> TestResult {
+        let ( $($name,)* ) = v.clone();
+        let f: fn($($name),*) -> T = *self;
+        let mut r = <TestResult as From<Result<T, String>>>::from(safe(move || {f($($name),*)}));
+
+        {
+            let ( $(ref $name,)* ) = v;
+            r.arguments = format!("{:?}", &($($name),*));
+        }
+        r
+    }
+}}}
+
+testable_fn!(A);
+testable_fn!(A, B);
+testable_fn!(A, B, C);
+testable_fn!(A, B, C, D);
+testable_fn!(A, B, C, D, E);
+testable_fn!(A, B, C, D, E, F);
+testable_fn!(A, B, C, D, E, F, G);
+testable_fn!(A, B, C, D, E, F, G, H);
+
+fn safe<T, F>(fun: F) -> Result<T, String>
+where
+    F: FnOnce() -> T,
+    F: 'static,
+    T: 'static,
+{
+    panic::catch_unwind(panic::AssertUnwindSafe(fun)).map_err(|any_err| {
+        // Extract common types of panic payload:
+        // panic and assert produce &str or String
+        if let Some(&s) = any_err.downcast_ref::<&str>() {
+            s.to_owned()
+        } else if let Some(s) = any_err.downcast_ref::<String>() {
+            s.to_owned()
+        } else {
+            "UNABLE TO SHOW RESULT OF PANIC.".to_owned()
+        }
+    })
+}

--- a/tests/tester.rs
+++ b/tests/tester.rs
@@ -1,0 +1,44 @@
+use sample_std::Random;
+use sample_test::{
+    env_logger_init,
+    tester::{sample_test, TestResult, Testable},
+};
+
+#[test]
+fn test_testable() {
+    fn test(a: usize, b: usize) -> bool {
+        let sum = a + b;
+        sum >= a && sum >= b
+    }
+
+    let mut r = Random::new(1000);
+    let s = (0..10, 0..10);
+    assert!(Testable::test_once(&(test as fn(usize, usize) -> bool), &s, &mut r).is_success());
+
+    sample_test(s, test as fn(usize, usize) -> bool);
+}
+
+#[test]
+fn test_shrink() {
+    let _ = crate::env_logger_init();
+
+    fn test(a: usize, b: usize) -> bool {
+        a <= 5 && b <= 5
+    }
+
+    let s = (0..10, 0..10);
+    assert_eq!(
+        Testable::shrink(
+            &(test as fn(usize, usize) -> bool),
+            &s,
+            TestResult::passed(),
+            (9, 9)
+        )
+        .arguments(),
+        // ranges attempt to shrink to their start first
+        // (0, 9) fails
+        // (0, 0) passes
+        // we then reverse-recurse down to the "smallest" failing value, (0, 6)
+        "(0, 6)"
+    );
+}


### PR DESCRIPTION
Most of this PR is the `SampleTest` implementation, which was basically copied with some fixes from [the `quickcheck` tester](https://github.com/BurntSushi/quickcheck/blob/master/src/tester.rs). There are several notable changes:

- Just using the `Debug` impl on tuples means there's no need to define a separate `shrink` function for each `Testable`. This simplifies the implementations and associated macro.
- We switch to an iterative shrinking procedure instead of a recursive one. This kills two birds with one stone:
  - Shrinking procedures that accidentally return infinite iterators will still eventually halt.
  - Stack overflows are no longer possible (see BurntSushi/quickcheck#285 for an example of this in `quickcheck`)

Aside from that, the `#[sample_test]` macro gets much simpler as we no longer need to derive `Arbitrary` newtypes for each sampler. This also makes it more ergonomic: you can now define values directly and use function calls instead of the prior `lazy_static` requirement.

The only downside is when using `once_cell::sync::Lazy` or `lazy_static`, you need to call `.clone()` (as we expect the sampler by-value and these constructs return a `Deref`). I don't think this is a major problem as the function-call or direct-value use cases are probably the common path.