### PR TITLE
Switch generate() to &mut self, various upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ edition = { workspace = true }
 members = ["sample-std", "sample-test-macros", "sample-arrow2"]
 
 [workspace.dependencies]
-sample-test = { path = ".", version = "0.1" }
-sample-std = { path = "sample-std", version = "0.1" }
-sample-test-macros = { path = "sample-test-macros", version = "0.1" }
+sample-test = { path = ".", version = "0.2" }
+sample-std = { path = "sample-std", version = "0.2" }
+sample-test-macros = { path = "sample-test-macros", version = "0.2" }
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/sample-std/src/recursive.rs
+++ b/sample-std/src/recursive.rs
@@ -36,7 +36,7 @@ where
 {
     type Output = N;
 
-    fn generate(&self, g: &mut Random) -> Self::Output {
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
         match &self.depth {
             Some(depth) => {
                 if depth.start > 0 {

--- a/sample-std/tests/recurse.rs
+++ b/sample-std/tests/recurse.rs
@@ -48,7 +48,7 @@ impl JsonSampler {
 impl Sample for JsonSampler {
     type Output = Json;
 
-    fn generate(&self, g: &mut Random) -> Json {
+    fn generate(&mut self, g: &mut Random) -> Json {
         match g.gen_range(0..=3) {
             0 => Json::Bool(g.arbitrary()),
             1 => Json::Number(g.arbitrary()),


### PR DESCRIPTION
This is obviously a breaking API change, thus the version bump.

The reasons to go to `&mut` are several, but here's the most important:

- Creating a new `Gen` object for each call to `generate` was insanely expensive. The hottest hot spot I've ever seen on a flame graph. Mainly due to pulling enough entropy to seed the RNG. I first experimented with moving it into `Random`, but that didn't sit right with me as many samplers have no need for `Arbitrary` and thus `Gen`.
- The intended use case (a unit test where sampled values are generated serially) is fully compatible with `&mut` samplers.
- It also allows us to do some hacky things in `sample-arrow2` (review coming) to get around the persistent issues with sampling arrow arrays due to length preallocation.

There are some additional tweaks and fixes in here, mostly as the changes to `sample-arrow2` evolved.