### PR TITLE
Support generation of arrow2 samplers from example data

### DIFF
--- a/sample-arrow2/Cargo.toml
+++ b/sample-arrow2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample-arrow2"
 description = "Samplers for arrow2 for use with sample-test"
-version = "0.17.1"
+version = "0.17.2"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -9,7 +9,9 @@ edition = "2021"
 
 [dependencies]
 sample-std = { workspace = true }
-arrow2 = "0.17"
+# arrow2 = "0.17"
+# arrow2 = { source = "git+https://github.com/WallarooLabs/arrow2?branch=fmurphy/public-arrow-parquet-schema#2294fd35a20300a7d3d300e5ca10d0af75ad2537" }
+arrow2 = { git = "https://github.com/WallarooLabs/arrow2", branch = "fmurphy/public-arrow-parquet-schema" }
 
 [dev-dependencies]
 quickcheck="1.0"

--- a/sample-arrow2/src/datatypes.rs
+++ b/sample-arrow2/src/datatypes.rs
@@ -18,7 +18,7 @@ where
 {
     type Output = Field;
 
-    fn generate(&self, g: &mut Random) -> Self::Output {
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
         Field::new(
             self.names.generate(g),
             self.inner.generate(g),
@@ -39,7 +39,7 @@ where
 {
     type Output = DataType;
 
-    fn generate(&self, g: &mut Random) -> Self::Output {
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
         let size = self.size.generate(g);
         DataType::Struct((0..size).map(|_| self.field.generate(g)).collect())
     }

--- a/sample-arrow2/src/fixed_size_list.rs
+++ b/sample-arrow2/src/fixed_size_list.rs
@@ -1,0 +1,60 @@
+//! Samplers for generating an arrow [`FixedSizeListArray`].
+
+use crate::{SampleLen, SetLen};
+use arrow2::{
+    array::{Array, FixedSizeListArray},
+    bitmap::Bitmap,
+    datatypes::{DataType, Field},
+};
+use sample_std::{Random, Sample};
+
+pub struct FixedSizeListWithLen<V, C, A, N> {
+    pub len: usize,
+    pub validity: V,
+    pub count: C,
+
+    pub inner: A,
+    pub inner_name: N,
+}
+
+impl<V: SetLen, C, A, N> SetLen for FixedSizeListWithLen<V, C, A, N> {
+    fn set_len(&mut self, len: usize) {
+        self.len = len;
+        self.validity.set_len(len);
+    }
+}
+
+impl<V, C, A, N> Sample for FixedSizeListWithLen<V, C, A, N>
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen,
+    C: Sample<Output = usize>,
+    A: Sample<Output = Box<dyn Array>> + SetLen,
+    N: Sample<Output = String>,
+{
+    type Output = Box<dyn Array>;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let count = self.count.generate(g);
+        self.inner.set_len(count * self.len);
+        let values = self.inner.generate(g);
+        let is_nullable = values.validity().is_some();
+        let inner_name = self.inner_name.generate(g);
+        let field = Field::new(inner_name, values.data_type().clone(), is_nullable);
+        let data_type = DataType::FixedSizeList(Box::new(field), count);
+        let validity = self.validity.generate(g);
+        FixedSizeListArray::new(data_type, values, validity).boxed()
+    }
+
+    fn shrink(&self, _: Self::Output) -> Box<dyn Iterator<Item = Self::Output>> {
+        Box::new(std::iter::empty())
+    }
+}
+
+impl<V, C, A, N> SampleLen for FixedSizeListWithLen<V, C, A, N>
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen,
+    C: Sample<Output = usize>,
+    A: Sample<Output = Box<dyn Array>> + SetLen,
+    N: Sample<Output = String>,
+{
+}

--- a/sample-arrow2/src/lib.rs
+++ b/sample-arrow2/src/lib.rs
@@ -1,20 +1,132 @@
 use arrow2::{array::Array, bitmap::Bitmap};
-use sample_std::{Random, Sample};
+use sample_std::{Random, Sample, SampleAll, Shrunk};
 
 pub mod array;
 pub mod chunk;
 pub mod datatypes;
+pub mod fixed_size_list;
 pub mod list;
 pub mod primitive;
 pub mod struct_;
 
 pub type ArrowSampler = Box<dyn Sample<Output = Box<dyn Array>> + Send + Sync>;
 
-pub(crate) fn generate_validity<V>(null: &Option<V>, g: &mut Random, len: usize) -> Option<Bitmap>
+pub(crate) fn generate_validity<V>(
+    null: &mut Option<V>,
+    g: &mut Random,
+    len: usize,
+) -> Option<Bitmap>
 where
     V: Sample<Output = bool>,
 {
-    null.as_ref().map(|null| {
+    null.as_mut().map(|null| {
         Bitmap::from_trusted_len_iter(std::iter::repeat(()).take(len).map(|_| !null.generate(g)))
     })
+}
+
+pub trait SetLen {
+    fn set_len(&mut self, len: usize);
+}
+
+#[derive(Debug, Clone)]
+pub struct AlwaysValid;
+
+impl Sample for AlwaysValid {
+    type Output = Option<Bitmap>;
+
+    fn generate(&mut self, _: &mut sample_std::Random) -> Self::Output {
+        None
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+impl SetLen for AlwaysValid {
+    fn set_len(&mut self, _: usize) {}
+}
+
+impl<C, I, O> SetLen for sample_std::TryConvert<C, I, O>
+where
+    C: SetLen,
+{
+    fn set_len(&mut self, len: usize) {
+        self.inner.set_len(len)
+    }
+}
+
+impl<S, F, I> SampleLen for sample_std::TryConvert<S, F, I>
+where
+    S: Sample + SetLen,
+    F: Fn(S::Output) -> Box<dyn Array>,
+    I: Fn(Box<dyn Array>) -> Option<S::Output>,
+{
+}
+
+impl<C> SetLen for sample_std::SamplerChoice<C>
+where
+    C: SetLen,
+{
+    fn set_len(&mut self, len: usize) {
+        for choice in &mut self.choices {
+            choice.set_len(len);
+        }
+    }
+}
+
+impl SampleLen for sample_std::SamplerChoice<ArrowLenSampler> {}
+
+impl<S: SetLen> SetLen for SampleAll<S> {
+    fn set_len(&mut self, len: usize) {
+        for sampler in &mut self.samplers {
+            sampler.set_len(len);
+        }
+    }
+}
+
+impl Sample for Box<dyn SampleLen> {
+    type Output = Box<dyn Array>;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        self.as_mut().generate(g)
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<'_, Self::Output> {
+        self.as_ref().shrink(v)
+    }
+}
+
+pub trait SampleLen: Sample<Output = Box<dyn Array>> + SetLen {}
+
+pub type ArrowLenSampler = Box<dyn SampleLen>;
+
+impl SetLen for ArrowLenSampler {
+    fn set_len(&mut self, len: usize) {
+        self.as_mut().set_len(len)
+    }
+}
+
+impl SampleLen for ArrowLenSampler {}
+
+pub struct FixedLenSampler<A> {
+    pub len: usize,
+    pub array: A,
+}
+
+impl<A> Sample for FixedLenSampler<A>
+where
+    A: Sample + SetLen,
+    A::Output: Clone,
+{
+    type Output = A::Output;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        self.array.set_len(self.len);
+        self.array.generate(g)
+    }
+
+    fn shrink(&self, array: Self::Output) -> Shrunk<Self::Output> {
+        self.array.shrink(array)
+    }
 }

--- a/sample-arrow2/src/struct_.rs
+++ b/sample-arrow2/src/struct_.rs
@@ -19,9 +19,9 @@ where
 {
     type Output = Box<dyn Array>;
 
-    fn generate(&self, g: &mut Random) -> Self::Output {
-        let values: Vec<_> = self.values.iter().map(|sa| sa.generate(g)).collect();
-        let validity = generate_validity(&self.null, g, values[0].len());
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let values: Vec<_> = self.values.iter_mut().map(|sa| sa.generate(g)).collect();
+        let validity = generate_validity(&mut self.null, g, values[0].len());
 
         StructArray::new(self.data_type.clone(), values, validity).boxed()
     }

--- a/sample-arrow2/tests/chunk.rs
+++ b/sample-arrow2/tests/chunk.rs
@@ -18,7 +18,7 @@ fn deep_chunk(depth: usize, len: usize) -> ArbitraryChunk<Regex, Chance> {
 
     let array = ArbitraryArray {
         names,
-        branch: 0..10,
+        branch: 0..5,
         len: len..(len + 1),
         null: Chance(0.1),
         is_nullable: true,

--- a/sample-arrow2/tests/fixed_size_list.rs
+++ b/sample-arrow2/tests/fixed_size_list.rs
@@ -1,0 +1,38 @@
+use arrow2::{
+    array::Array,
+    datatypes::{DataType, Field},
+};
+use sample_arrow2::{array::FromDataType, AlwaysValid, FixedLenSampler};
+use sample_std::Sample;
+use sample_test::sample_test;
+use std::boxed::Box;
+
+pub type ArraySampler = Box<dyn Sample<Output = Box<dyn Array>>>;
+
+fn fixed(len: usize, count: usize) -> ArraySampler {
+    let data_type = DataType::FixedSizeList(
+        Box::new(Field::new("inner".to_string(), DataType::UInt8, false)),
+        count,
+    );
+
+    let any = FromDataType {
+        validity: AlwaysValid,
+        branch: 0..10,
+    };
+
+    Box::new(FixedLenSampler {
+        len,
+        array: any.from_data_type(&data_type),
+    })
+}
+
+#[sample_test]
+fn fixed_size_list_equality(#[sample(fixed(10, 30))] mut array: Box<dyn Array>) {
+    assert_eq!(array.len(), 10);
+    assert_eq!(array, array);
+    if array.len() > 2 {
+        let before = array.clone();
+        array.slice(0, array.len() / 2);
+        assert_ne!(before, array);
+    }
+}


### PR DESCRIPTION
This is so, so ugly. But I can't think of a better way to do it. Basically, you need to "preheat" each sampler by setting the expected length _before_ you can sample from them. This is used recursively; `FixedSizeListArray` and `ListArray` must mutate their own inner samplers as part of `generate`. Ew.

I ended up liking this more than the other ideas I considered:

- You can't just statically set an outer length the entire way down, because `ListArray` in particular may have different inner sizes for every generation.
- One way to look at it is the composed / chained samplers: generate a sampler that generates stuff of the exact fixed length. I kinda hated this as it gets very abstract very quickly (e.g. Chunks in theory have the same thing going on?), the types are a pain, and it doesn't seem particularly efficient.

This whole library probably needs to be rethought as part of the next arrow2 upgrade. For now, let's just deal with the warts for the stuff we know is working.