### PR TITLE
Add sample-arrow-rs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = ["sample-std", "sample-test-macros", "sample-arrow2"]
+members = ["sample-std", "sample-test-macros", "sample-arrow2", "sample-arrow-rs"]
 
 [workspace.dependencies]
 sample-test = { path = ".", version = "0.2" }

--- a/sample-arrow-rs/Cargo.toml
+++ b/sample-arrow-rs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sample-arrow-rs"
+description = "Samplers for arrow-rs for use with sample-test"
+version = "55.2.0"
+license = "Apache-2.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sample-std = { workspace = true }
+arrow-array = "55.2.0"
+arrow-schema = "55.2.0"
+arrow-data = "55.2.0"
+arrow-buffer = "55.2.0"
+
+[dev-dependencies]
+quickcheck="1.0"
+sample-test = { workspace = true }
+lazy_static = "1.4"

--- a/sample-arrow-rs/README.md
+++ b/sample-arrow-rs/README.md
@@ -1,0 +1,21 @@
+# sample-arrow-rs
+
+This crate provides samplers for [arrow-rs](https://github.com/apache/arrow-rs) for use with [sample-test](https://github.com/BlockScience/sample-test).
+
+It allows you to generate random Arrow arrays for testing purposes.
+
+## Usage
+
+```rust
+use sample_arrow_rs::array::primitive_array;
+use sample_test::Sample;
+use arrow::array::Int32Array;
+
+let mut sampler = primitive_array::<Int32Array>();
+let array = sampler.sample().unwrap();
+```
+
+## Features
+
+- Samplers for various Arrow array types
+- Integration with sample-test for property-based testing

--- a/sample-arrow-rs/src/array.rs
+++ b/sample-arrow-rs/src/array.rs
@@ -1,0 +1,195 @@
+//! Chained samplers for generating arbitrary `Arc<dyn Array>` arrow arrays.
+
+use std::ops::Range;
+
+use arrow_array::{Array, ArrayRef, FixedSizeListArray, ListArray};
+use arrow_schema::DataType;
+use sample_std::{Always, Chained, Sample};
+
+use crate::{
+    datatypes::DataTypeSampler,
+    fixed_size_list::FixedSizeListWithLen,
+    list::{ListSampler, ListWithLen},
+    primitive::{
+        f32_array, f32_sampler, f64_array, f64_sampler, i16_array, i16_sampler, i32_array,
+        i32_sampler, i64_array, i64_sampler, i8_array, i8_sampler, u16_array, u16_sampler,
+        u32_array, u32_sampler, u64_array, u64_sampler, u8_array, u8_sampler,
+    },
+    struct_::StructSampler,
+    AlwaysValid, ArrowLenSampler, SetLen,
+};
+
+pub fn sampler_from_example(array: &dyn Array) -> ArrowLenSampler {
+    match array.data_type() {
+        DataType::Float32 => f32_sampler(AlwaysValid),
+        DataType::Float64 => f64_sampler(AlwaysValid),
+        DataType::Int8 => i8_sampler(AlwaysValid),
+        DataType::Int16 => i16_sampler(AlwaysValid),
+        DataType::Int32 => i32_sampler(AlwaysValid),
+        DataType::Int64 => i64_sampler(AlwaysValid),
+        DataType::UInt8 => u8_sampler(AlwaysValid),
+        DataType::UInt16 => u16_sampler(AlwaysValid),
+        DataType::UInt32 => u32_sampler(AlwaysValid),
+        DataType::UInt64 => u64_sampler(AlwaysValid),
+        DataType::List(_) => {
+            let list = array.as_any().downcast_ref::<ListArray>().unwrap();
+            // In arrow-rs we access offsets differently
+            let _offsets_buffer = list.offsets();
+            // Get the raw values as a slice - arrow-rs uses different methods
+            // than arrow2, we'll try to access offsets directly
+            let offsets = list.value_offsets();
+            let lengths: Vec<_> = offsets.windows(2).map(|w| w[1] - w[0]).collect();
+            let min = lengths.iter().min().copied().unwrap_or(0) as i32;
+            let max = lengths.iter().max().copied().unwrap_or(0) as i32 + 1;
+
+            // In arrow-rs, field information comes from the data_type
+            let field_name = if let DataType::List(field) = array.data_type() {
+                field.name().clone()
+            } else {
+                "item".to_string() // Fallback
+            };
+
+            Box::new(ListWithLen {
+                len: array.len(),
+                validity: AlwaysValid,
+                count: min..max,
+                inner_name: Always(field_name),
+                inner: sampler_from_example(list.values()),
+            })
+        }
+        DataType::FixedSizeList(field, size) => {
+            let list = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+            Box::new(FixedSizeListWithLen {
+                len: array.len(),
+                validity: AlwaysValid,
+                count: Always(*size as i64),
+                inner_name: Always(field.name().clone()),
+                inner: sampler_from_example(list.values()),
+            })
+        }
+        dt => panic!("not implemented: {:?}", dt),
+    }
+}
+
+pub struct FromDataType<V, B> {
+    pub validity: V,
+    pub branch: B,
+}
+
+impl<V, B> FromDataType<V, B>
+where
+    V: Sample<Output = Option<crate::Bitmap>> + SetLen + Clone + Send + Sync + 'static,
+    B: Sample<Output = i32> + Clone + Send + Sync + 'static,
+{
+    pub fn from_data_type(&self, data_type: &DataType) -> ArrowLenSampler {
+        match data_type {
+            DataType::Float32 => f32_sampler(self.validity.clone()),
+            DataType::Float64 => f64_sampler(self.validity.clone()),
+            DataType::Int8 => i8_sampler(self.validity.clone()),
+            DataType::Int16 => i16_sampler(self.validity.clone()),
+            DataType::Int32 => i32_sampler(self.validity.clone()),
+            DataType::Int64 => i64_sampler(self.validity.clone()),
+            DataType::UInt8 => u8_sampler(self.validity.clone()),
+            DataType::UInt16 => u16_sampler(self.validity.clone()),
+            DataType::UInt32 => u32_sampler(self.validity.clone()),
+            DataType::UInt64 => u64_sampler(self.validity.clone()),
+            DataType::List(field) => Box::new(ListWithLen {
+                len: 0,
+                validity: self.validity.clone(),
+                count: self.branch.clone(),
+                inner_name: Always(field.name().clone()),
+                inner: self.from_data_type(field.data_type()),
+            }),
+            DataType::FixedSizeList(field, size) => Box::new(FixedSizeListWithLen {
+                len: 0,
+                validity: self.validity.clone(),
+                count: Always(*size as i64),
+                inner_name: Always(field.name().clone()),
+                inner: self.from_data_type(field.data_type()),
+            }),
+            dt => panic!("not implemented: {:?}", dt),
+        }
+    }
+}
+
+pub type ArraySampler = Box<dyn Sample<Output = ArrayRef> + Send + Sync>;
+
+pub type ChainedArraySampler = Box<dyn Sample<Output = Chained<DataType, ArrayRef>> + Send + Sync>;
+
+#[derive(Clone, Debug)]
+pub struct ArbitraryArray<N, V> {
+    pub names: N,
+    pub branch: Range<usize>,
+    pub len: Range<usize>,
+    pub null: V,
+    pub is_nullable: bool,
+}
+
+impl<N, V> ArbitraryArray<N, V>
+where
+    N: Sample<Output = String> + Send + Sync + Clone + 'static,
+    V: Sample<Output = bool> + Send + Sync + Clone + 'static,
+{
+    pub fn with_len(&self, len: usize) -> Self {
+        Self {
+            len: len..(len + 1),
+            ..self.clone()
+        }
+    }
+
+    pub fn arbitrary_array(self, data_type_sampler: DataTypeSampler) -> ChainedArraySampler {
+        Box::new(data_type_sampler.chain_resample(
+            move |data_type| self.sampler_from_data_type(&data_type),
+            100,
+        ))
+    }
+
+    pub fn sampler_from_data_type(&self, data_type: &DataType) -> ArraySampler {
+        let current_null = if self.is_nullable {
+            Some(self.null.clone())
+        } else {
+            None
+        };
+        let len = self.len.clone();
+
+        match data_type {
+            DataType::Float32 => f32_array(len.clone(), current_null),
+            DataType::Float64 => f64_array(len.clone(), current_null),
+            DataType::Int8 => i8_array(len.clone(), current_null),
+            DataType::Int16 => i16_array(len.clone(), current_null),
+            DataType::Int32 => i32_array(len.clone(), current_null),
+            DataType::Int64 => i64_array(len.clone(), current_null),
+            DataType::UInt8 => u8_array(len.clone(), current_null),
+            DataType::UInt16 => u16_array(len.clone(), current_null),
+            DataType::UInt32 => u32_array(len.clone(), current_null),
+            DataType::UInt64 => u64_array(len.clone(), current_null),
+            DataType::Struct(fields) => Box::new(StructSampler {
+                data_type: data_type.clone(),
+                null: current_null,
+                values: fields
+                    .iter()
+                    .map(|f| {
+                        ArbitraryArray {
+                            len: (len.end.saturating_sub(1))..len.end,
+                            is_nullable: f.is_nullable(),
+                            ..self.clone()
+                        }
+                        .sampler_from_data_type(f.data_type())
+                    })
+                    .collect(),
+            }),
+            DataType::List(field) => Box::new(ListSampler {
+                data_type: data_type.clone(),
+                len: len.clone(),
+                null: current_null,
+                inner: ArbitraryArray {
+                    branch: (self.branch.start * self.len.start)..(self.branch.end * self.len.end),
+                    is_nullable: field.is_nullable(),
+                    ..self.clone()
+                }
+                .sampler_from_data_type(field.data_type()),
+            }),
+            dt => panic!("not implemented: {:?}", dt),
+        }
+    }
+}

--- a/sample-arrow-rs/src/chunk.rs
+++ b/sample-arrow-rs/src/chunk.rs
@@ -1,0 +1,123 @@
+//! Chained samplers for generating arbitrary `RecordBatch` arrow record batches.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use sample_std::{sample_all, Chained, Random, Sample, Shrunk, VecSampler};
+
+use crate::{array::ArbitraryArray, datatypes::DataTypeSampler};
+
+// In arrow-rs, we use RecordBatch instead of Chunk
+pub type ChainedChunk = Chained<(Vec<DataType>, usize), RecordBatch>;
+pub type ChainedMultiChunk = Chained<(Vec<DataType>, Vec<usize>), Vec<RecordBatch>>;
+
+pub struct ArbitraryChunk<N, V> {
+    pub chunk_len: Range<usize>,
+    pub array_count: Range<usize>,
+    pub data_type: DataTypeSampler,
+    pub array: ArbitraryArray<N, V>,
+}
+
+struct RecordBatchSampler {
+    arrays_sampler: Box<dyn Sample<Output = Vec<ArrayRef>> + Send + Sync>,
+    schema: Arc<Schema>,
+}
+
+impl Sample for RecordBatchSampler {
+    type Output = RecordBatch;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        // Generate the arrays
+        let arrays = self.arrays_sampler.generate(g);
+
+        // Create the record batch
+        RecordBatch::try_new(self.schema.clone(), arrays)
+            .unwrap_or_else(|_| panic!("Failed to create record batch"))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+impl<N, V> ArbitraryChunk<N, V>
+where
+    N: Sample<Output = String> + Send + Sync + Clone + 'static,
+    V: Sample<Output = bool> + Send + Sync + Clone + 'static,
+{
+    pub fn sample_one(self) -> Box<dyn Sample<Output = ChainedChunk> + Send + Sync> {
+        Box::new(
+            VecSampler {
+                length: self.array_count,
+                el: self.data_type,
+            }
+            .zip(self.chunk_len)
+            .chain_resample(move |seed| Self::from_seed(&self.array, seed), 100),
+        )
+    }
+
+    pub fn sample_many(
+        self,
+        chunk_count: Range<usize>,
+    ) -> Box<dyn Sample<Output = ChainedMultiChunk> + Send + Sync> {
+        Box::new(
+            VecSampler {
+                length: self.array_count,
+                el: self.data_type,
+            }
+            .zip(VecSampler {
+                length: chunk_count,
+                el: self.chunk_len,
+            })
+            .chain_resample(
+                move |(dts, lens)| {
+                    sample_all(
+                        lens.into_iter()
+                            .map(|len| Self::from_seed(&self.array, (dts.clone(), len)))
+                            .collect(),
+                    )
+                },
+                100,
+            ),
+        )
+    }
+
+    pub fn from_seed(
+        array: &ArbitraryArray<N, V>,
+        seed: (Vec<DataType>, usize),
+    ) -> Box<dyn Sample<Output = RecordBatch> + Send + Sync> {
+        let (dts, len) = seed;
+
+        // Create field names for the schema
+        let field_names: Vec<String> = dts
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("field_{}", i))
+            .collect();
+
+        // Create fields for the schema
+        let fields: Vec<Field> = dts
+            .iter()
+            .zip(field_names.iter())
+            .map(|(dt, name)| Field::new(name, dt.clone(), true))
+            .collect();
+
+        // Create the schema
+        let schema = Arc::new(Schema::new(fields));
+
+        // Generate arrays from data types
+        let arrays_sampler = sample_all(
+            dts.into_iter()
+                .map(|data_type| array.with_len(len).sampler_from_data_type(&data_type))
+                .collect(),
+        );
+
+        // Create the record batch sample generator
+        Box::new(RecordBatchSampler {
+            arrays_sampler: Box::new(arrays_sampler),
+            schema,
+        })
+    }
+}

--- a/sample-arrow-rs/src/datatypes.rs
+++ b/sample-arrow-rs/src/datatypes.rs
@@ -1,0 +1,156 @@
+//! Samplers for generating an arrow [`DataType`].
+
+use arrow_schema::{DataType, Field, Fields};
+use sample_std::{sampler_choice, Always, Random, Sample, Shrunk};
+use std::sync::Arc;
+
+pub type DataTypeSampler = Box<dyn Sample<Output = DataType> + Send + Sync>;
+
+struct FieldSampler<N, V> {
+    names: N,
+    nullable: V,
+    inner: DataTypeSampler,
+}
+
+impl<N, V> Sample for FieldSampler<N, V>
+where
+    N: Sample<Output = String>,
+    V: Sample<Output = bool>,
+{
+    type Output = Field;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        // In arrow-rs, Field::new takes name, data_type, is_nullable
+        Field::new(
+            self.names.generate(g),
+            self.inner.generate(g),
+            self.nullable.generate(g),
+        )
+    }
+}
+
+struct StructDataTypeSampler<S, F> {
+    size: S,
+    field: F,
+}
+
+impl<S, F> Sample for StructDataTypeSampler<S, F>
+where
+    S: Sample<Output = usize>,
+    F: Sample<Output = Field>,
+{
+    type Output = DataType;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let size = self.size.generate(g);
+        let fields = (0..size)
+            .map(|_| self.field.generate(g))
+            .collect::<Fields>();
+        // In arrow-rs, we use the struct constructor directly
+        DataType::Struct(fields)
+    }
+}
+
+pub fn sample_flat() -> DataTypeSampler {
+    Box::new(sampler_choice([
+        Always(DataType::Float32),
+        Always(DataType::Float64),
+        Always(DataType::Int8),
+        Always(DataType::Int16),
+        Always(DataType::Int32),
+        Always(DataType::Int64),
+        Always(DataType::UInt8),
+        Always(DataType::UInt16),
+        Always(DataType::UInt32),
+        Always(DataType::UInt64),
+    ]))
+}
+
+pub struct ArbitraryDataType<N, V, B, F> {
+    pub names: N,
+    pub nullable: V,
+    pub struct_branch: B,
+    pub flat: F,
+}
+
+impl<N, V, B, F> ArbitraryDataType<N, V, B, F>
+where
+    N: Sample<Output = String> + Clone + Send + Sync + 'static,
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+    B: Sample<Output = usize> + Clone + Send + Sync + 'static,
+    F: Fn() -> DataTypeSampler,
+{
+    pub fn sample_nested<IF>(&self, inner: IF) -> DataTypeSampler
+    where
+        IF: Fn() -> DataTypeSampler + Clone,
+    {
+        let names_clone = self.names.clone();
+        let nullable_clone = self.nullable.clone();
+        let inner_clone = inner.clone();
+
+        // Create a field constructor that can be used multiple times
+        let field_constructor = move || FieldSampler {
+            names: names_clone.clone(),
+            nullable: nullable_clone.clone(),
+            inner: inner_clone(),
+        };
+
+        // Create a list type sampler
+        let list_field_sampler = {
+            let names_clone = self.names.clone();
+            let nullable_clone = self.nullable.clone();
+            let inner_clone = inner.clone();
+
+            move || {
+                // Create a field sampler for the list element
+                let field_sampler = FieldSampler {
+                    names: names_clone.clone(),
+                    nullable: nullable_clone.clone(),
+                    inner: inner_clone(),
+                };
+
+                // Create a sampler that produces DataType::List with the generated field
+                Box::new(ListFieldSampler { field_sampler }) as DataTypeSampler
+            }
+        };
+
+        Box::new(sampler_choice([
+            Box::new((self.flat)()) as DataTypeSampler,
+            Box::new(StructDataTypeSampler {
+                size: self.struct_branch.clone(),
+                field: field_constructor(),
+            }),
+            list_field_sampler(),
+        ]))
+    }
+
+    pub fn sample_depth(&self, depth: usize) -> DataTypeSampler {
+        let flats = (self.flat)();
+        if depth == 0 {
+            flats
+        } else {
+            let inner = || self.sample_depth(depth - 1);
+            Box::new(sampler_choice([self.sample_nested(inner), flats]))
+        }
+    }
+}
+
+struct ListFieldSampler<F> {
+    field_sampler: F,
+}
+
+impl<F> Sample for ListFieldSampler<F>
+where
+    F: Sample<Output = Field>,
+{
+    type Output = DataType;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let field = self.field_sampler.generate(g);
+        DataType::List(Arc::new(field))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}

--- a/sample-arrow-rs/src/fixed_size_list.rs
+++ b/sample-arrow-rs/src/fixed_size_list.rs
@@ -1,0 +1,66 @@
+//! Samplers for generating an arrow [`FixedSizeListArray`].
+
+use std::sync::Arc;
+
+use arrow_array::{Array, ArrayRef, FixedSizeListArray};
+use arrow_schema::Field;
+use sample_std::{Random, Sample, Shrunk};
+
+use crate::{SampleLen, SetLen};
+
+pub struct FixedSizeListWithLen<V, C, A, N> {
+    pub len: usize,
+    pub validity: V,
+    pub count: C,
+    pub inner: A,
+    pub inner_name: N,
+}
+
+impl<V: SetLen, C, A, N> SetLen for FixedSizeListWithLen<V, C, A, N> {
+    fn set_len(&mut self, len: usize) {
+        self.len = len;
+        self.validity.set_len(len);
+    }
+}
+
+impl<V, C, A, N> Sample for FixedSizeListWithLen<V, C, A, N>
+where
+    V: Sample<Output = Option<crate::Bitmap>> + SetLen,
+    C: Sample<Output = i64>, // Using i64 for size in arrow-rs
+    A: Sample<Output = ArrayRef> + SetLen,
+    N: Sample<Output = String>,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let count = self.count.generate(g) as i32; // Convert to i32 for arrow-rs
+        self.inner.set_len(count as usize * self.len);
+        let values = self.inner.generate(g);
+        let is_nullable = values.nulls().is_some();
+        let inner_name = self.inner_name.generate(g);
+        let field = Arc::new(Field::new(
+            inner_name,
+            values.data_type().clone(),
+            is_nullable,
+        ));
+
+        // Convert the validity bitmap to a NullBuffer if present
+        let null_buffer = self.validity.generate(g).map(|bitmap| bitmap);
+
+        // Create a FixedSizeListArray
+        Arc::new(FixedSizeListArray::new(field, count, values, null_buffer))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+impl<V, C, A, N> SampleLen for FixedSizeListWithLen<V, C, A, N>
+where
+    V: Sample<Output = Option<crate::Bitmap>> + SetLen,
+    C: Sample<Output = i64>,
+    A: Sample<Output = ArrayRef> + SetLen,
+    N: Sample<Output = String>,
+{
+}

--- a/sample-arrow-rs/src/lib.rs
+++ b/sample-arrow-rs/src/lib.rs
@@ -1,0 +1,136 @@
+use arrow_array::ArrayRef;
+use arrow_buffer::NullBuffer;
+use sample_std::{Random, Sample, SampleAll, Shrunk};
+
+// Define Bitmap as an alias for NullBuffer to make the transition smoother
+pub type Bitmap = NullBuffer;
+
+pub mod array;
+pub mod chunk;
+pub mod datatypes;
+pub mod fixed_size_list;
+pub mod list;
+pub mod primitive;
+pub mod struct_;
+
+// Use ArrayRef directly (Arc<dyn Array>)
+pub type ArrowSampler = Box<dyn Sample<Output = ArrayRef> + Send + Sync>;
+
+pub(crate) fn generate_validity<V>(
+    null: &mut Option<V>,
+    g: &mut Random,
+    len: usize,
+) -> Option<Bitmap>
+where
+    V: Sample<Output = bool>,
+{
+    null.as_mut()
+        .map(|null| Bitmap::from_iter(std::iter::repeat(()).take(len).map(|_| !null.generate(g))))
+}
+
+pub trait SetLen {
+    fn set_len(&mut self, len: usize);
+}
+
+#[derive(Debug, Clone)]
+pub struct AlwaysValid;
+
+impl Sample for AlwaysValid {
+    type Output = Option<Bitmap>;
+
+    fn generate(&mut self, _: &mut sample_std::Random) -> Self::Output {
+        None
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+impl SetLen for AlwaysValid {
+    fn set_len(&mut self, _: usize) {}
+}
+
+impl<C, I, O> SetLen for sample_std::TryConvert<C, I, O>
+where
+    C: SetLen,
+{
+    fn set_len(&mut self, len: usize) {
+        self.inner.set_len(len)
+    }
+}
+
+impl<S, F, I> SampleLen for sample_std::TryConvert<S, F, I>
+where
+    S: Sample + SetLen,
+    F: Fn(S::Output) -> ArrayRef,
+    I: Fn(ArrayRef) -> Option<S::Output>,
+{
+}
+
+impl<C> SetLen for sample_std::SamplerChoice<C>
+where
+    C: SetLen,
+{
+    fn set_len(&mut self, len: usize) {
+        for choice in &mut self.choices {
+            choice.set_len(len);
+        }
+    }
+}
+
+impl SampleLen for sample_std::SamplerChoice<ArrowLenSampler> {}
+
+impl<S: SetLen> SetLen for SampleAll<S> {
+    fn set_len(&mut self, len: usize) {
+        for sampler in &mut self.samplers {
+            sampler.set_len(len);
+        }
+    }
+}
+
+impl Sample for Box<dyn SampleLen> {
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        self.as_mut().generate(g)
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<'_, Self::Output> {
+        self.as_ref().shrink(v)
+    }
+}
+
+pub trait SampleLen: Sample<Output = ArrayRef> + SetLen {}
+
+pub type ArrowLenSampler = Box<dyn SampleLen>;
+
+impl SetLen for ArrowLenSampler {
+    fn set_len(&mut self, len: usize) {
+        self.as_mut().set_len(len)
+    }
+}
+
+impl SampleLen for ArrowLenSampler {}
+
+pub struct FixedLenSampler<A> {
+    pub len: usize,
+    pub array: A,
+}
+
+impl<A> Sample for FixedLenSampler<A>
+where
+    A: Sample + SetLen,
+    A::Output: Clone,
+{
+    type Output = A::Output;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        self.array.set_len(self.len);
+        self.array.generate(g)
+    }
+
+    fn shrink(&self, array: Self::Output) -> Shrunk<Self::Output> {
+        self.array.shrink(array)
+    }
+}

--- a/sample-arrow-rs/src/list.rs
+++ b/sample-arrow-rs/src/list.rs
@@ -1,0 +1,135 @@
+//! Samplers for generating an arrow [`ListArray`].
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_array::{Array, ArrayRef, ListArray};
+use arrow_buffer::OffsetBuffer;
+use arrow_schema::{DataType, Field};
+use sample_std::{Random, Sample, Shrunk};
+
+use crate::{generate_validity, ArrowSampler, Bitmap, SampleLen, SetLen};
+
+pub struct ListSampler<V> {
+    pub data_type: DataType,
+    pub len: Range<usize>,
+    pub null: Option<V>,
+    pub inner: ArrowSampler,
+}
+
+impl<V> Sample for ListSampler<V>
+where
+    V: Sample<Output = bool> + Send + Sync + 'static,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let values = self.inner.generate(g);
+        let len = g.gen_range(self.len.clone());
+        let mut ix = 0;
+        let mut offsets = vec![0i32];
+
+        for outer_ix in 0..len {
+            if outer_ix + 1 != len {
+                let remaining = values.len() - ix;
+                let fair = std::cmp::max(2, remaining / (len - outer_ix));
+                let upper = std::cmp::min(values.len() - ix, fair);
+                let count = g.gen_range(0..=upper);
+                ix += count;
+                offsets.push(ix as i32);
+            } else {
+                offsets.push(values.len() as i32);
+            }
+        }
+
+        let validity = generate_validity(&mut self.null, g, len);
+        // Convert our custom Bitmap type to arrow's NullBuffer
+        let null_buffer = validity.map(|bitmap| bitmap);
+
+        // Convert offsets to a ScalarBuffer first, then to an OffsetBuffer
+        let scalar_buffer = arrow_buffer::ScalarBuffer::from(offsets);
+        let offsets_buffer = OffsetBuffer::new(scalar_buffer);
+
+        let field = if let DataType::List(field) = &self.data_type {
+            field.clone()
+        } else {
+            panic!("Expected List data type")
+        };
+
+        // Create the ListArray and return as Arc<dyn Array>
+        Arc::new(ListArray::new(field, offsets_buffer, values, null_buffer))
+    }
+
+    fn shrink(&self, _v: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+pub struct ListWithLen<V, C, A, N> {
+    pub len: usize,
+    pub validity: V,
+    pub count: C,
+    pub inner: A,
+    pub inner_name: N,
+}
+
+impl<V: SetLen, C, A, N> SetLen for ListWithLen<V, C, A, N> {
+    fn set_len(&mut self, len: usize) {
+        self.len = len;
+        self.validity.set_len(len);
+    }
+}
+
+impl<V, C, A, N> Sample for ListWithLen<V, C, A, N>
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen,
+    C: Sample<Output = i32>,
+    A: Sample<Output = ArrayRef> + SetLen,
+    N: Sample<Output = String>,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let mut offsets = vec![0];
+        let mut inner_len: i32 = 0;
+        for _ in 0..self.len {
+            let count = self.count.generate(g);
+            assert!(count >= 0);
+            inner_len += count;
+            offsets.push(inner_len);
+        }
+
+        self.inner.set_len(inner_len as usize);
+        let values = self.inner.generate(g);
+        let is_nullable = values.nulls().is_some();
+        let inner_name = self.inner_name.generate(g);
+        let field = Arc::new(Field::new(
+            inner_name,
+            values.data_type().clone(),
+            is_nullable,
+        ));
+
+        // Convert offsets to a ScalarBuffer first, then to an OffsetBuffer
+        let scalar_buffer = arrow_buffer::ScalarBuffer::from(offsets);
+        let offsets_buffer = OffsetBuffer::new(scalar_buffer);
+
+        // Convert the validity bitmap to a NullBuffer if present
+        let null_buffer = self.validity.generate(g).map(|bitmap| bitmap);
+
+        // Create the ListArray
+        Arc::new(ListArray::new(field, offsets_buffer, values, null_buffer))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+impl<V, C, A, N> SampleLen for ListWithLen<V, C, A, N>
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen,
+    C: Sample<Output = i32>,
+    A: Sample<Output = ArrayRef> + SetLen,
+    N: Sample<Output = String>,
+{
+}

--- a/sample-arrow-rs/src/primitive.rs
+++ b/sample-arrow-rs/src/primitive.rs
@@ -1,0 +1,416 @@
+//! Samplers for generating an arrow [`PrimitiveArray`].
+
+use std::marker::PhantomData;
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, ArrowPrimitiveType, PrimitiveArray};
+use arrow_buffer::ScalarBuffer;
+use sample_std::{
+    arbitrary, sampler_choice, valid_f32, valid_f64, Random, Sample, Shrunk, VecSampler,
+};
+
+use crate::{ArrowLenSampler, ArrowSampler, Bitmap, SampleLen, SetLen};
+
+#[derive(Debug, Clone)]
+pub struct PrimitiveArraySampler<PT, V, T> {
+    len: usize,
+    inner: PT,
+    validity: V,
+    _phantom: PhantomData<T>,
+}
+
+impl<PT, V, T> SetLen for PrimitiveArraySampler<PT, V, T>
+where
+    V: SetLen,
+{
+    fn set_len(&mut self, len: usize) {
+        self.len = len;
+        self.validity.set_len(len);
+    }
+}
+
+impl<PT, V, T> SampleLen for PrimitiveArraySampler<PT, V, T>
+where
+    PT: Sample + 'static,
+    T: ArrowPrimitiveType + 'static,
+    T::Native: From<PT::Output>,
+    V: Sample<Output = Option<Bitmap>> + SetLen + 'static,
+{
+}
+
+impl<PT, V, T> Sample for PrimitiveArraySampler<PT, V, T>
+where
+    PT: Sample,
+    T: ArrowPrimitiveType,
+    T::Native: From<PT::Output>,
+    V: Sample<Output = Option<Bitmap>> + SetLen,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        // Generate values and convert to T::Native
+        let values: Vec<T::Native> = (0..self.len)
+            .map(|_| T::Native::from(self.inner.generate(g)))
+            .collect();
+
+        // Convert to ScalarBuffer
+        let values_buffer = ScalarBuffer::from(values);
+
+        // Generate validity and convert to NullBuffer if present
+        let null_buffer = self.validity.generate(g).map(|bitmap| bitmap);
+
+        // Create the primitive array and return as Arc<dyn Array>
+        Arc::new(PrimitiveArray::<T>::new(values_buffer, null_buffer))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+pub fn primitive_len_sampler<PT, V, T>(inner: PT, validity: V) -> ArrowLenSampler
+where
+    PT: Sample + 'static,
+    T: ArrowPrimitiveType + 'static,
+    T::Native: From<PT::Output>,
+    V: Sample<Output = Option<Bitmap>> + SetLen + 'static,
+{
+    Box::new(PrimitiveArraySampler::<PT, V, T> {
+        len: 0,
+        inner,
+        validity,
+        _phantom: PhantomData,
+    })
+}
+
+// Helper to implement samplers for int types (i8, i16, i32, etc.)
+macro_rules! primitive_samplers {
+    ($type:ty, $arrow_type:ty, $fn_name:ident) => {
+        pub fn $fn_name(
+            validity: impl Sample<Output = Option<Bitmap>> + SetLen + Clone + 'static,
+        ) -> ArrowLenSampler {
+            primitive_len_sampler::<_, _, $arrow_type>(arbitrary::<$type>(), validity)
+        }
+    };
+}
+
+// Implement primitive samplers for different arrow types
+primitive_samplers!(i8, arrow_array::types::Int8Type, i8_sampler);
+primitive_samplers!(i16, arrow_array::types::Int16Type, i16_sampler);
+primitive_samplers!(i32, arrow_array::types::Int32Type, i32_sampler);
+primitive_samplers!(i64, arrow_array::types::Int64Type, i64_sampler);
+primitive_samplers!(u8, arrow_array::types::UInt8Type, u8_sampler);
+primitive_samplers!(u16, arrow_array::types::UInt16Type, u16_sampler);
+primitive_samplers!(u32, arrow_array::types::UInt32Type, u32_sampler);
+primitive_samplers!(u64, arrow_array::types::UInt64Type, u64_sampler);
+primitive_samplers!(f32, arrow_array::types::Float32Type, f32_sampler);
+primitive_samplers!(f64, arrow_array::types::Float64Type, f64_sampler);
+
+pub fn valid_float_len_sampler<V>(valid: V) -> ArrowLenSampler
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen + Clone + 'static,
+{
+    Box::new(sampler_choice([
+        primitive_len_sampler::<_, _, arrow_array::types::Float32Type>(valid_f32(), valid.clone()),
+        primitive_len_sampler::<_, _, arrow_array::types::Float64Type>(valid_f64(), valid),
+    ]))
+}
+
+pub fn arbitrary_int_len_sampler<V>(valid: V) -> ArrowLenSampler
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen + Clone + 'static,
+{
+    Box::new(sampler_choice([
+        i8_sampler(valid.clone()),
+        i16_sampler(valid.clone()),
+        i32_sampler(valid.clone()),
+        i64_sampler(valid.clone()),
+    ]))
+}
+
+pub fn arbitrary_uint_len_sampler<V>(valid: V) -> ArrowLenSampler
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen + Clone + 'static,
+{
+    Box::new(sampler_choice([
+        u8_sampler(valid.clone()),
+        u16_sampler(valid.clone()),
+        u32_sampler(valid.clone()),
+        u64_sampler(valid.clone()),
+    ]))
+}
+
+pub fn valid_primitive_len<V>(valid: V) -> ArrowLenSampler
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen + Clone + 'static,
+{
+    Box::new(sampler_choice([
+        valid_float_len_sampler(valid.clone()),
+        arbitrary_int_len_sampler(valid.clone()),
+        arbitrary_uint_len_sampler(valid.clone()),
+    ]))
+}
+
+pub fn arbitrary_primitive_len<V>(valid: V) -> ArrowLenSampler
+where
+    V: Sample<Output = Option<Bitmap>> + SetLen + Clone + 'static,
+{
+    valid_primitive_len(valid)
+}
+
+#[derive(Debug, Clone)]
+pub struct ProtoNullablePrimitiveArray<PT, T> {
+    inner: VecSampler<Range<usize>, PT>,
+    _phantom: PhantomData<T>,
+}
+
+impl<PT, N, T> Sample for ProtoNullablePrimitiveArray<PT, T>
+where
+    PT: Sample<Output = Option<N>> + Clone + 'static,
+    N: Clone + 'static,
+    T: ArrowPrimitiveType + 'static,
+    T::Native: From<N>,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        // Generate optional values
+        let values: Vec<Option<T::Native>> = self
+            .inner
+            .generate(g)
+            .into_iter()
+            .map(|opt| opt.map(T::Native::from))
+            .collect();
+
+        // Use from_iter to create a PrimitiveArray with nulls
+        Arc::new(PrimitiveArray::<T>::from_iter(values))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProtoPrimitiveArray<PT, T> {
+    inner: VecSampler<Range<usize>, PT>,
+    _phantom: PhantomData<T>,
+}
+
+impl<PT, N, T> Sample for ProtoPrimitiveArray<PT, T>
+where
+    PT: Sample<Output = N> + Clone + 'static,
+    N: Clone + 'static,
+    T: ArrowPrimitiveType + 'static,
+    T::Native: From<N>,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        // Generate values
+        let values: Vec<T::Native> = self
+            .inner
+            .generate(g)
+            .into_iter()
+            .map(T::Native::from)
+            .collect();
+
+        // Create a ScalarBuffer
+        let buffer = ScalarBuffer::from(values);
+
+        // Create PrimitiveArray and return as Arc<dyn Array>
+        Arc::new(PrimitiveArray::<T>::new(buffer, None))
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+#[derive(Clone)]
+pub struct ProtoBoxedNullablePrimitiveArray<PT, T> {
+    inner: ProtoNullablePrimitiveArray<PT, T>,
+}
+
+impl<PT, N, T> Sample for ProtoBoxedNullablePrimitiveArray<PT, T>
+where
+    PT: Sample<Output = Option<N>> + Clone + 'static,
+    N: Clone + 'static,
+    T: ArrowPrimitiveType + 'static,
+    T::Native: From<N>,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        self.inner.generate(g)
+    }
+
+    fn shrink(&self, _: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}
+
+pub fn boxed_nullable<GT, N, T>(len: Range<usize>, el: GT) -> ArrowSampler
+where
+    GT: Sample<Output = Option<N>> + Send + Sync + Clone + 'static,
+    N: Clone + Send + Sync + 'static,
+    T: ArrowPrimitiveType + Send + Sync + 'static,
+    T::Native: From<N>,
+{
+    Box::new(ProtoBoxedNullablePrimitiveArray {
+        inner: ProtoNullablePrimitiveArray {
+            inner: VecSampler { length: len, el },
+            _phantom: PhantomData::<T>,
+        },
+    })
+}
+
+pub fn boxed<GT, N, T>(len: Range<usize>, el: GT) -> ArrowSampler
+where
+    GT: Sample<Output = N> + Send + Sync + Clone + 'static,
+    N: Clone + Send + Sync + 'static,
+    T: ArrowPrimitiveType + Send + Sync + 'static,
+    T::Native: From<N>,
+{
+    Box::new(ProtoPrimitiveArray {
+        inner: VecSampler { length: len, el },
+        _phantom: PhantomData::<T>,
+    })
+}
+
+#[derive(Clone)]
+struct Nullable<SI, V> {
+    inner: SI,
+    null: V,
+}
+
+impl<SI, V> Sample for Nullable<SI, V>
+where
+    SI: Sample,
+    V: Sample<Output = bool>,
+{
+    type Output = Option<SI::Output>;
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        if self.null.generate(g) {
+            None
+        } else {
+            Some(self.inner.generate(g))
+        }
+    }
+
+    fn shrink(&self, v: Self::Output) -> Shrunk<Self::Output> {
+        if let Some(v) = v {
+            Box::new(std::iter::once(None).chain(self.inner.shrink(v).map(Some)))
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+}
+
+// Helper macro to create boxed_primitive functions
+macro_rules! boxed_primitives {
+    ($type:ty, $arrow_type:ty, $fn_name:ident) => {
+        pub fn $fn_name<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+        where
+            V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+        {
+            match null {
+                Some(null) => boxed_nullable::<_, $type, $arrow_type>(
+                    len.clone(),
+                    Nullable {
+                        inner: arbitrary::<$type>(),
+                        null,
+                    },
+                ),
+                None => boxed::<_, $type, $arrow_type>(len.clone(), arbitrary::<$type>()),
+            }
+        }
+    };
+}
+
+// Implement boxed_primitive functions
+boxed_primitives!(i8, arrow_array::types::Int8Type, i8_array);
+boxed_primitives!(i16, arrow_array::types::Int16Type, i16_array);
+boxed_primitives!(i32, arrow_array::types::Int32Type, i32_array);
+boxed_primitives!(i64, arrow_array::types::Int64Type, i64_array);
+boxed_primitives!(u8, arrow_array::types::UInt8Type, u8_array);
+boxed_primitives!(u16, arrow_array::types::UInt16Type, u16_array);
+boxed_primitives!(u32, arrow_array::types::UInt32Type, u32_array);
+boxed_primitives!(u64, arrow_array::types::UInt64Type, u64_array);
+boxed_primitives!(f32, arrow_array::types::Float32Type, f32_array);
+boxed_primitives!(f64, arrow_array::types::Float64Type, f64_array);
+
+pub fn valid_float_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(sampler_choice([
+        f32_array(len.clone(), null.clone()),
+        f64_array(len, null),
+    ]))
+}
+
+pub fn arbitrary_float_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    valid_float_array(len, null)
+}
+
+pub fn arbitrary_int_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(sampler_choice([
+        i8_array(len.clone(), null.clone()),
+        i16_array(len.clone(), null.clone()),
+        i32_array(len.clone(), null.clone()),
+        i64_array(len.clone(), null.clone()),
+    ]))
+}
+
+pub fn arbitrary_uint_array<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(sampler_choice([
+        u8_array(len.clone(), null.clone()),
+        u16_array(len.clone(), null.clone()),
+        u32_array(len.clone(), null.clone()),
+        u64_array(len.clone(), null.clone()),
+    ]))
+}
+
+pub fn valid_primitive<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    Box::new(sampler_choice([
+        valid_float_array(len.clone(), null.clone()),
+        arbitrary_int_array(len.clone(), null.clone()),
+        arbitrary_uint_array(len.clone(), null.clone()),
+    ]))
+}
+
+pub fn arbitrary_primitive<V>(len: Range<usize>, null: Option<V>) -> ArrowSampler
+where
+    V: Sample<Output = bool> + Clone + Send + Sync + 'static,
+{
+    valid_primitive(len, null)
+}
+
+#[cfg(test)]
+mod tests {
+    use sample_std::Chance;
+
+    use super::*;
+
+    #[test]
+    fn gen_float() {
+        let mut gen = valid_float_array(50..51, Some(Chance(0.5)));
+        let mut r = Random::new();
+        let arr = gen.generate(&mut r);
+        assert_eq!(arr.len(), 50);
+    }
+}

--- a/sample-arrow-rs/src/struct_.rs
+++ b/sample-arrow-rs/src/struct_.rs
@@ -1,0 +1,40 @@
+//! Samplers for generating an arrow [`StructArray`].
+
+use arrow_array::{Array, ArrayRef, StructArray};
+use arrow_schema::DataType;
+use sample_std::{Random, Sample, Shrunk};
+use std::sync::Arc;
+
+use crate::{generate_validity, ArrowSampler};
+
+pub struct StructSampler<V> {
+    pub data_type: DataType,
+    pub null: Option<V>,
+    pub values: Vec<ArrowSampler>,
+}
+
+impl<V> Sample for StructSampler<V>
+where
+    V: Sample<Output = bool>,
+{
+    type Output = ArrayRef;
+
+    fn generate(&mut self, g: &mut Random) -> Self::Output {
+        let arrays: Vec<ArrayRef> = self.values.iter_mut().map(|sa| sa.generate(g)).collect();
+        let validity = generate_validity(&mut self.null, g, arrays[0].len());
+
+        // Extract fields from the data_type
+        let fields = if let DataType::Struct(fields) = &self.data_type {
+            fields.clone()
+        } else {
+            panic!("Expected Struct data type")
+        };
+
+        // Create the struct array as ArrayRef
+        Arc::new(StructArray::new(fields, arrays, validity))
+    }
+
+    fn shrink(&self, _v: Self::Output) -> Shrunk<Self::Output> {
+        Box::new(std::iter::empty())
+    }
+}

--- a/sample-arrow-rs/tests/array.rs
+++ b/sample-arrow-rs/tests/array.rs
@@ -1,0 +1,44 @@
+use arrow_array::{Array, ArrayRef};
+use arrow_schema::DataType;
+use sample_arrow_rs::{
+    array::{ArbitraryArray, ChainedArraySampler},
+    datatypes::{sample_flat, ArbitraryDataType},
+};
+use sample_std::{Chained, Chance, Regex};
+use sample_test::sample_test;
+use std::boxed::Box;
+
+fn deep_array(depth: usize) -> ChainedArraySampler {
+    let names = Regex::new("[a-z]{4,8}");
+    let dt = ArbitraryDataType {
+        struct_branch: 1..3,
+        names: names.clone(),
+        nullable: Chance(0.5),
+        flat: sample_flat,
+    }
+    .sample_depth(depth);
+
+    Box::new(
+        ArbitraryArray {
+            names,
+            branch: 0..10,
+            len: 10..11,
+            null: Chance(0.1),
+            is_nullable: true,
+        }
+        .arbitrary_array(dt),
+    )
+}
+
+#[sample_test]
+fn list_equality(#[sample(deep_array(3))] list: Chained<DataType, ArrayRef>) {
+    let list = &list.value;
+    assert_eq!(list.len(), 10);
+
+    // In arrow-rs, we need to create a new slice rather than modifying in-place
+    if list.len() > 2 {
+        let before = list.clone();
+        let sliced = list.slice(0, list.len() / 2);
+        assert_ne!(before.len(), sliced.len());
+    }
+}

--- a/sample-arrow-rs/tests/chunk.rs
+++ b/sample-arrow-rs/tests/chunk.rs
@@ -1,0 +1,45 @@
+use sample_arrow_rs::{
+    array::ArbitraryArray,
+    chunk::{ArbitraryChunk, ChainedChunk, ChainedMultiChunk},
+    datatypes::{sample_flat, ArbitraryDataType},
+};
+use sample_std::{Chance, Regex};
+use sample_test::sample_test;
+
+fn deep_chunk(depth: usize, len: usize) -> ArbitraryChunk<Regex, Chance> {
+    let names = Regex::new("[a-z]{4,8}");
+    let data_type = ArbitraryDataType {
+        struct_branch: 1..3,
+        names: names.clone(),
+        nullable: Chance(0.5),
+        flat: sample_flat,
+    }
+    .sample_depth(depth);
+
+    let array = ArbitraryArray {
+        names,
+        branch: 0..5,
+        len: len..(len + 1),
+        null: Chance(0.1),
+        is_nullable: true,
+    };
+
+    ArbitraryChunk {
+        chunk_len: 10..100,
+        array_count: 4..6,
+        data_type,
+        array,
+    }
+}
+
+#[sample_test]
+fn arbitrary_chunk(#[sample(deep_chunk(3, 100).sample_one())] chunk: ChainedChunk) {
+    let chunk = chunk.value;
+    assert_eq!(chunk, chunk);
+}
+
+#[sample_test]
+fn arbitrary_chunks(#[sample(deep_chunk(3, 100).sample_many(2..10))] chunk: ChainedMultiChunk) {
+    let chunk = chunk.value;
+    assert_eq!(chunk, chunk);
+}

--- a/sample-arrow-rs/tests/fixed_size_list.rs
+++ b/sample-arrow-rs/tests/fixed_size_list.rs
@@ -1,0 +1,38 @@
+use arrow_array::{Array, ArrayRef};
+use arrow_schema::{DataType, Field};
+use sample_arrow_rs::{array::FromDataType, AlwaysValid, FixedLenSampler};
+use sample_std::Sample;
+use sample_test::sample_test;
+use std::boxed::Box;
+use std::sync::Arc;
+
+pub type ArraySampler = Box<dyn Sample<Output = ArrayRef>>;
+
+fn fixed(len: usize, count: usize) -> ArraySampler {
+    let data_type = DataType::FixedSizeList(
+        Arc::new(Field::new("inner", DataType::UInt8, false)),
+        count as i32,
+    );
+
+    let any = FromDataType {
+        validity: AlwaysValid,
+        branch: 0..10,
+    };
+
+    Box::new(FixedLenSampler {
+        len,
+        array: any.from_data_type(&data_type),
+    })
+}
+
+#[sample_test]
+fn fixed_size_list_equality(#[sample(fixed(10, 30))] array: ArrayRef) {
+    assert_eq!(array.len(), 10);
+
+    // In arrow-rs, we need to create a new slice rather than modifying in-place
+    if array.len() > 2 {
+        let before = array.clone();
+        let sliced = array.slice(0, array.len() / 2);
+        assert_ne!(before.len(), sliced.len());
+    }
+}


### PR DESCRIPTION
Full disclosure: this was completely translated from the existing arrow2 sampler by Goose and qwen3-coder.

I've been poking at it as much as I can and it seems to preserve / do everything that we want. I've looked through the generated data; it is varied, has different datatypes, has different combinations of nullabilities, and has arbitrary nesting. I can post some samples when we do the final integration with plateau (which I have also tested locally).

There's a couple code warts I don't _love_ but I don't think are worth the effort to address given the context here (this code is basically the engine of the automated fuzzer that we use for testing in plateau).

The other oddity here is the version. It follows the versioning strategy used throughout this project, where the sampler version matches the major and minor version of the target crate. I still think this is appropriate; I don't want any users to need to "map" between sample crate versions and the version of the crate they are shadowing.